### PR TITLE
Hotfix/name propagation

### DIFF
--- a/wkcuber/cube_io.py
+++ b/wkcuber/cube_io.py
@@ -11,20 +11,20 @@ def get_cube_folder(target_path, mag, x, y, z):
                      'z{:04d}'.format(z))
 
 
-def get_cube_file_name(mag, x, y, z):
-    return '{:s}_mag{:d}_x{:04d}_y{:04d}_z{:04d}.raw'.format('', mag, x, y, z)
+def get_cube_file_name(name, mag, x, y, z):
+    return '{:s}_mag{:d}_x{:04d}_y{:04d}_z{:04d}.raw'.format(name, mag, x, y, z)
 
 
-def get_cube_full_path(target_path, mag, x, y, z):
+def get_cube_full_path(target_path, name, mag, x, y, z):
     return path.join(get_cube_folder(target_path, mag, x, y, z),
-                     get_cube_file_name(mag, x, y, z))
+                     get_cube_file_name(name, mag, x, y, z))
 
 
-def write_cube(target_path, cube_data, mag, x, y, z):
+def write_cube(target_path, name, cube_data, mag, x, y, z):
     ref_time = time.time()
 
     prefix = get_cube_folder(target_path, mag, x, y, z)
-    file_name = get_cube_file_name(mag, x, y, z)
+    file_name = get_cube_file_name(name, mag, x, y, z)
     cube_full_path = path.join(prefix, file_name)
 
     if not path.exists(prefix):
@@ -40,11 +40,11 @@ def write_cube(target_path, cube_data, mag, x, y, z):
         logging.error("Could not write cube: {0}".format(cube_full_path))
 
 
-def read_cube(target_path, mag, cube_edge_len, x, y, z, dtype):
+def read_cube(target_path, name, mag, cube_edge_len, x, y, z, dtype):
     ref_time = time.time()
 
     prefix = get_cube_folder(target_path, mag, x, y, z)
-    file_name = get_cube_file_name(mag, x, y, z)
+    file_name = get_cube_file_name(name, mag, x, y, z)
     cube_full_path = path.join(prefix, file_name)
 
     if not path.exists(prefix):

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -154,6 +154,6 @@ def make_mag1_cubes_from_z_stack(config, cubing_info):
                 cube_data = cube_buffer[i].swapaxes(0, 1).swapaxes(1, 2)
                 # pool.submit(write_cube, cube_data,
                 #             target_path, 1, cube_x, cube_y, cube_z)
-                write_cube(target_path, cube_data, 1, cube_x, cube_y, cube_z)
+                write_cube(target_path, config['dataset']['name'], cube_data, 1, cube_x, cube_y, cube_z)
                 logging.info("Cube written: {},{},{} mag {}".format(
                     cube_x, cube_y, cube_z, 1))

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -64,7 +64,7 @@ def downsample_cube_job(config, source_mag, target_mag,
         'processing']['skip_already_downsampled_cubes']
 
     cube_full_path = get_cube_full_path(
-        target_path, target_mag, cube_x, cube_y, cube_z)
+        target_path, config['dataset']['name'], target_mag, cube_x, cube_y, cube_z)
     if skip_already_downsampled_cubes and path.exists(cube_full_path):
         logging.debug("Skipping downsampling {},{},{} mag {}".format(
             cube_x, cube_y, cube_z, target_mag))
@@ -79,7 +79,7 @@ def downsample_cube_job(config, source_mag, target_mag,
         for local_y in range(factor):
             for local_z in range(factor):
                 cube_data = read_cube(
-                    target_path, source_mag, cube_edge_len,
+                    target_path, config['dataset']['name'], source_mag, cube_edge_len,
                     cube_x * factor + local_x,
                     cube_y * factor + local_y,
                     cube_z * factor + local_z,
@@ -94,7 +94,7 @@ def downsample_cube_job(config, source_mag, target_mag,
                 ] = cube_data
 
     cube_data = downsample_cube(cube_buffer, factor, dtype)
-    write_cube(target_path, cube_data, target_mag, cube_x, cube_y, cube_z)
+    write_cube(target_path, config['dataset']['name'], cube_data, target_mag, cube_x, cube_y, cube_z)
 
     logging.debug("Downsampling took {:.8f}s".format(
         time.time() - ref_time))


### PR DESCRIPTION
Propagates the dataset naming config value into the get_cube_file_name, get_cube_full_path, read_cube, write_cube and make_mag1_cubes_from_z_stack functions.

Fix required to allow automated processing / deployment of datasets and prevents name collision.