### PR TITLE
Feature/latest-webknossos-data-api

### DIFF
--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -29,13 +29,15 @@ def write_webknossos_metadata(dataset_base_path,
                     'category': layer_type,
                     'elementClass': dtype,
                     'sections': [
-                        'name': '',
-                        'resolutions': resolutions,
-                        'boundingBox': {
-                            "topLeft": [0, 0, 0],
-                            "width": bbox[0],
-                            "height": bbox[1],
-                            "depth": bbox[2]
+                        {
+                            'name': '',
+                            'resolutions': resolutions,
+                            'boundingBox': {
+                                "topLeft": [0, 0, 0],
+                                "width": bbox[0],
+                                "height": bbox[1],
+                                "depth": bbox[2]
+                            }
                         }
                     ]
                 }

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -13,7 +13,37 @@ def write_webknossos_metadata(dataset_base_path,
 
     if not path.exists(dataset_base_path):
         makedirs(dataset_base_path)
+        
+    # Generate a combined metadata file (for webknossos). Currently have no source of information for team and elementClass
+    datasource_properites_path = path.join(dataset_base_path, 'datasource-properties.json')
+    with open(datasource_properties_path, 'wt') as datasource_properties_json:
+      json.dump({
+            'id': {
+                'name': name,
+                'team': '',
+            },
+            'dataLayers': [
+                {
+                    'dataFormat': 'knossos',
+                    'name': layer_name,
+                    'category': layer_type,
+                    'elementClass': '',
+                    'sections': [
+                        'name': '',
+                        'resolutions': resolutions,
+                        'boundingBox': {
+                            "topLeft": [0, 0, 0],
+                            "width": bbox[0],
+                            "height": bbox[1],
+                            "depth": bbox[2]
+                        }
+                    ]
+                }
+            ],
+            'scale': scale
+      }, datasource_properties_json)
 
+    # These can possibly be removed but should be deprecated for a period of time
     settings_json_path = path.join(dataset_base_path, 'settings.json')
     with open(settings_json_path, 'wt') as settings_json:
         json.dump({

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -14,7 +14,7 @@ def write_webknossos_metadata(dataset_base_path,
     if not path.exists(dataset_base_path):
         makedirs(dataset_base_path)
         
-    # Generate a combined metadata file (for webknossos). Currently have no source of information for team and elementClass
+    # Generate a combined metadata file (for webknossos). Currently have no source of information for team
     datasource_properites_path = path.join(dataset_base_path, 'datasource-properties.json')
     with open(datasource_properties_path, 'wt') as datasource_properties_json:
       json.dump({
@@ -27,7 +27,7 @@ def write_webknossos_metadata(dataset_base_path,
                     'dataFormat': 'knossos',
                     'name': layer_name,
                     'category': layer_type,
-                    'elementClass': '',
+                    'elementClass': dtype,
                     'sections': [
                         'name': '',
                         'resolutions': resolutions,


### PR DESCRIPTION
PLEASE NOTE: No tests have been run against this PR, please test before accepting!

This should add support for the latest data api in webknossos. I have not removed the older metadata jsons in case they are used by others. Perhaps a deprecation phase should be employed?

resolves #8 