### PR TITLE
add read_metadata_for_layer function

### DIFF
--- a/wkcuber/__init__.py
+++ b/wkcuber/__init__.py
@@ -1,4 +1,4 @@
 from .cubing import cubing
 from .downsampling import downsample_mag
 from .compress import compress_mag
-from .metadata import write_webknossos_metadata, read_metadata_for_layer
+from .metadata import write_webknossos_metadata

--- a/wkcuber/__init__.py
+++ b/wkcuber/__init__.py
@@ -1,4 +1,4 @@
 from .cubing import cubing
 from .downsampling import downsample_mag
 from .compress import compress_mag
-from .metadata import write_webknossos_metadata
+from .metadata import write_webknossos_metadata, read_metadata_for_layer

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -55,6 +55,18 @@ def write_webknossos_metadata(
         )
 
 
+def read_metadata_for_layer(wkw_path, layer_name):
+        datasource_properties = json.load(open(path.join(wkw_path, 'datasource-properties.json'), 'r'))
+        layers = datasource_properties['dataLayers']
+        layer_info = next(layer for layer in layers if layer['name'] == layer_name)
+        dtype = np.dtype(layer_info['elementClass'])
+        bounding_box = layer_info['boundingBox']
+        origin = bounding_box['topLeft']
+        bounding_box = [bounding_box['width'], bounding_box['height'], bounding_box['depth']]
+
+        return layer_info, dtype, bounding_box, origin
+
+
 def detect_dtype(dataset_path, layer, mag=1):
     layer_path = path.join(dataset_path, layer, str(mag))
     if path.exists(layer_path):

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -56,15 +56,21 @@ def write_webknossos_metadata(
 
 
 def read_metadata_for_layer(wkw_path, layer_name):
-        datasource_properties = json.load(open(path.join(wkw_path, 'datasource-properties.json'), 'r'))
-        layers = datasource_properties['dataLayers']
-        layer_info = next(layer for layer in layers if layer['name'] == layer_name)
-        dtype = np.dtype(layer_info['elementClass'])
-        bounding_box = layer_info['boundingBox']
-        origin = bounding_box['topLeft']
-        bounding_box = [bounding_box['width'], bounding_box['height'], bounding_box['depth']]
+    datasource_properties = json.load(
+        open(path.join(wkw_path, "datasource-properties.json"), "r")
+    )
+    layers = datasource_properties["dataLayers"]
+    layer_info = next(layer for layer in layers if layer["name"] == layer_name)
+    dtype = np.dtype(layer_info["elementClass"])
+    bounding_box = layer_info["boundingBox"]
+    origin = bounding_box["topLeft"]
+    bounding_box = [
+        bounding_box["width"],
+        bounding_box["height"],
+        bounding_box["depth"],
+    ]
 
-        return layer_info, dtype, bounding_box, origin
+    return layer_info, dtype, bounding_box, origin
 
 
 def detect_dtype(dataset_path, layer, mag=1):


### PR DESCRIPTION
This PR adds a function to parse the datasource-properties.json file.
Given a layer name the function returns dtype, bounding_box , origin, and the corresponding layer field of the properties file.