### PR TITLE
Exact bounding box

### DIFF
--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -114,6 +114,10 @@ if __name__ == "__main__":
     )
 
     scale = tuple(float(x) for x in args.scale.split(","))
-    write_webknossos_metadata(args.target_path, args.name, scale,
-                              compute_max_id=False,
-                              exact_bounding_box=bounding_box)
+    write_webknossos_metadata(
+        args.target_path,
+        args.name,
+        scale,
+        compute_max_id=False,
+        exact_bounding_box=bounding_box,
+    )

--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    cubing(
+    bounding_box = cubing(
         args.source_path,
         args.target_path,
         args.layer_name,
@@ -114,4 +114,6 @@ if __name__ == "__main__":
     )
 
     scale = tuple(float(x) for x in args.scale.split(","))
-    write_webknossos_metadata(args.target_path, args.name, scale, compute_max_id=False)
+    write_webknossos_metadata(args.target_path, args.name, scale,
+                              compute_max_id=False,
+                              exact_bounding_box=bounding_box)

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -120,8 +120,9 @@ def cubing_job(target_wkw_info, z_batches, source_file_batches, batch_size, imag
                 raise exc
 
 
-def cubing(source_path, target_path, layer_name, dtype, batch_size, jobs) \
-        -> Tuple[int, int, int]:
+def cubing(
+    source_path, target_path, layer_name, dtype, batch_size, jobs
+) -> Tuple[int, int, int]:
 
     target_wkw_info = WkwDatasetInfo(target_path, layer_name, dtype, 1)
     source_files = find_source_filenames(source_path)

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -1,11 +1,8 @@
 import time
 import logging
 import numpy as np
-import wkw
 from argparse import ArgumentParser
-from os import path, listdir
-from PIL import Image
-from typing import Tuple
+from os import path
 
 from .utils import (
     get_chunks,
@@ -120,9 +117,7 @@ def cubing_job(target_wkw_info, z_batches, source_file_batches, batch_size, imag
                 raise exc
 
 
-def cubing(
-    source_path, target_path, layer_name, dtype, batch_size, jobs
-) -> Tuple[int, int, int]:
+def cubing(source_path, target_path, layer_name, dtype, batch_size, jobs) -> dict:
 
     target_wkw_info = WkwDatasetInfo(target_path, layer_name, dtype, 1)
     source_files = find_source_filenames(source_path)
@@ -147,7 +142,9 @@ def cubing(
                 batch_size,
                 (num_x, num_y),
             )
-    return (num_x, num_y, num_z)
+
+    # Return Bounding Box
+    return {"topLeft": [0, 0, 0], "width": num_x, "height": num_y, "depth": num_z}
 
 
 if __name__ == "__main__":

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -5,6 +5,7 @@ import wkw
 from argparse import ArgumentParser
 from os import path, listdir
 from PIL import Image
+from typing import Tuple
 
 from .utils import (
     get_chunks,
@@ -119,7 +120,9 @@ def cubing_job(target_wkw_info, z_batches, source_file_batches, batch_size, imag
                 raise exc
 
 
-def cubing(source_path, target_path, layer_name, dtype, batch_size, jobs):
+def cubing(source_path, target_path, layer_name, dtype, batch_size, jobs) \
+        -> Tuple[int, int, int]:
+
     target_wkw_info = WkwDatasetInfo(target_path, layer_name, dtype, 1)
     source_files = find_source_filenames(source_path)
 
@@ -143,6 +146,7 @@ def cubing(source_path, target_path, layer_name, dtype, batch_size, jobs):
                 batch_size,
                 (num_x, num_y),
             )
+    return (num_x, num_y, num_z)
 
 
 if __name__ == "__main__":

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from argparse import ArgumentParser
 from glob import iglob
-from os import path, makedirs, listdir
-from typing import Tuple, Optional
+from os import path, listdir
+from typing import Optional
 
 
 def create_parser():
@@ -43,7 +43,7 @@ def write_webknossos_metadata(
     scale,
     max_id=0,
     compute_max_id=False,
-    exact_bounding_box: Optional[Tuple[int, int, int]] = None,
+    exact_bounding_box: Optional[dict] = None,
 ):
 
     # Generate a metadata file for webKnossos
@@ -136,11 +136,10 @@ def detect_resolutions(dataset_path, layer):
 def detect_standard_layer(dataset_path, layer_name, exact_bounding_box=None):
     # Perform metadata detection for well-known layers
 
-    if exact_bounding_box is not None:
-        width, height, depth = exact_bounding_box
-        bbox = {"topLeft": [0, 0, 0], "width": width, "height": height, "depth": depth}
-    else:
+    if exact_bounding_box is None:
         bbox = detect_bbox(dataset_path, layer_name)
+    else:
+        bbox = exact_bounding_box
 
     dtype = detect_dtype(dataset_path, layer_name)
 

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -38,15 +38,20 @@ def create_parser():
 
 
 def write_webknossos_metadata(
-    dataset_path, name, scale, max_id=0, compute_max_id=False,
-    exact_bounding_box: Optional[Tuple[int, int, int]] = None
+    dataset_path,
+    name,
+    scale,
+    max_id=0,
+    compute_max_id=False,
+    exact_bounding_box: Optional[Tuple[int, int, int]] = None,
 ):
 
     # Generate a metadata file for webKnossos
     # Currently includes no source of information for team
     datasource_properties_path = path.join(dataset_path, "datasource-properties.json")
-    layers = list(detect_layers(dataset_path, max_id, compute_max_id,
-                                exact_bounding_box))
+    layers = list(
+        detect_layers(dataset_path, max_id, compute_max_id, exact_bounding_box)
+    )
     with open(datasource_properties_path, "wt") as datasource_properties_json:
         json.dump(
             {
@@ -133,12 +138,7 @@ def detect_standard_layer(dataset_path, layer_name, exact_bounding_box=None):
 
     if exact_bounding_box is not None:
         width, height, depth = exact_bounding_box
-        bbox = {
-            "topLeft": [0, 0, 0],
-            "width": width,
-            "height": height,
-            "depth": depth,
-        }
+        bbox = {"topLeft": [0, 0, 0], "width": width, "height": height, "depth": depth}
     else:
         bbox = detect_bbox(dataset_path, layer_name)
 
@@ -164,11 +164,10 @@ def detect_standard_layer(dataset_path, layer_name, exact_bounding_box=None):
     }
 
 
-def detect_segmentation_layer(dataset_path, layer_name, max_id,
-                              compute_max_id=False,
-                              exact_bounding_box=None):
-    layer_info = detect_standard_layer(dataset_path, layer_name,
-                                       exact_bounding_box)
+def detect_segmentation_layer(
+    dataset_path, layer_name, max_id, compute_max_id=False, exact_bounding_box=None
+):
+    layer_info = detect_standard_layer(dataset_path, layer_name, exact_bounding_box)
     layer_info["mappings"] = []
     layer_info["largestSegmentId"] = max_id
 
@@ -201,8 +200,7 @@ def detect_layers(dataset_path, max_id, compute_max_id, exact_bounding_box=None)
         yield detect_standard_layer(dataset_path, "color", exact_bounding_box)
     if path.exists(path.join(dataset_path, "segmentation")):
         yield detect_segmentation_layer(
-            dataset_path, "segmentation", max_id, compute_max_id,
-            exact_bounding_box
+            dataset_path, "segmentation", max_id, compute_max_id, exact_bounding_box
         )
 
 


### PR DESCRIPTION
When cubing with `python -m wkcuber`, it writes the exact bounding box into the `datasource-properties.json`, i.e., it does not round up to full cubes.