### PR TITLE
Add assert that files are found

### DIFF
--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -61,6 +61,9 @@ def find_source_filenames(source_path):
     source_files = list(
         find_files(path.join(source_path, "*"), image_reader.readers.keys())
     )
+    assert (
+        len(source_files) > 0
+    ), f"No image files found in path {source_path}. Supported suffixes are {str(image_reader.readers.keys())}."
     source_files.sort()
     return source_files
 


### PR DESCRIPTION
On the crick cluster, it still doesn't seem to find any files. To verify this, I added an assert that prints the known file formats if it fails.