### PR TITLE
Enable tiff cubing for multi-channel data

### DIFF
--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -17,8 +17,8 @@ source_info = WkwDatasetInfo("testdata/WT1_wkw", "color", "uint8", 1)
 target_info = WkwDatasetInfo("testoutput/WT1_wkw", "color", "uint8", 2)
 
 
-def read_wkw(wkw_info, offset, size, block_type=None):
-    with open_wkw(wkw_info, block_type=block_type) as wkw_dataset:
+def read_wkw(wkw_info, offset, size, **kwargs):
+    with open_wkw(wkw_info, **kwargs) as wkw_dataset:
         return wkw_dataset.read(offset, size)[0]
 
 

--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -74,7 +74,7 @@ def downsample_test_helper(use_compress):
         target_info,
         tuple(a * WKW_CUBE_SIZE for a in offset),
         (CUBE_EDGE_LEN,) * 3,
-        block_type,
+        block_type=block_type,
     )
     assert np.any(target_buffer != 0)
 

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -76,7 +76,14 @@ def read_image_file(file_name, dtype):
         raise exc
 
 
-def cubing_job(target_wkw_info, z_batches, source_file_batches, batch_size, image_size, num_channels):
+def cubing_job(
+    target_wkw_info,
+    z_batches,
+    source_file_batches,
+    batch_size,
+    image_size,
+    num_channels,
+):
     if len(z_batches) == 0:
         return
 

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -177,7 +177,7 @@ def downsample_cube_job(
         )
 
         with open_wkw(source_wkw_info) as source_wkw, open_wkw(
-            target_wkw_info, pool_get_lock(), header_block_type
+            target_wkw_info, pool_get_lock(), block_type=header_block_type
         ) as target_wkw:
             wkw_cubelength = source_wkw.header.file_len * source_wkw.header.block_len
 

--- a/wkcuber/image_readers.py
+++ b/wkcuber/image_readers.py
@@ -27,6 +27,7 @@ class PillowImageReader:
             else:
                 return this_layer.shape[-1]
 
+
 def to_target_datatype(data: np.ndarray, target_dtype) -> np.ndarray:
 
     factor = (1 + np.iinfo(data.dtype).max) / (1 + np.iinfo(target_dtype).max)

--- a/wkcuber/image_readers.py
+++ b/wkcuber/image_readers.py
@@ -1,4 +1,5 @@
 import numpy as np
+import logging
 from os import path
 from PIL import Image
 
@@ -17,6 +18,14 @@ class PillowImageReader:
         with Image.open(file_name) as test_img:
             return (test_img.width, test_img.height)
 
+    def read_channel_count(self, file_name):
+        with Image.open(file_name) as test_img:
+            this_layer = np.array(test_img)
+            if this_layer.ndim == 2:
+                # For two-dimensional data, the channel count is one
+                return 1
+            else:
+                return this_layer.shape[-1]
 
 def to_target_datatype(data: np.ndarray, target_dtype) -> np.ndarray:
 
@@ -35,6 +44,10 @@ class Dm3ImageReader:
     def read_dimensions(self, file_name):
         test_img = DM3(file_name)
         return (test_img.width, test_img.height)
+
+    def read_channel_count(self, file_name):
+        logging.info("Assuming single channel for DM3 data")
+        return 1
 
 
 class Dm4ImageReader:
@@ -85,6 +98,10 @@ class Dm4ImageReader:
 
         return dimensions
 
+    def read_channel_count(self, file_name):
+        logging.info("Assuming single channel for DM4 data")
+        return 1
+
 
 class ImageReader:
     def __init__(self):
@@ -105,6 +122,10 @@ class ImageReader:
     def read_dimensions(self, file_name):
         _, ext = path.splitext(file_name)
         return self.readers[ext].read_dimensions(file_name)
+
+    def read_channel_count(self, file_name):
+        _, ext = path.splitext(file_name)
+        return self.readers[ext].read_channel_count(file_name)
 
 
 image_reader = ImageReader()

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -20,24 +20,21 @@ WkwDatasetInfo = namedtuple(
 KnossosDatasetInfo = namedtuple("KnossosDatasetInfo", ("dataset_path", "dtype"))
 
 
-def _open_wkw(info, block_type=None):
-    header = wkw.Header(np.dtype(info.dtype))
-    if block_type is not None:
-        header.block_type = block_type
-    logging.debug("setting block_type to {}".format(header.block_type))
+def _open_wkw(info, **kwargs):
+    header = wkw.Header(np.dtype(info.dtype), **kwargs)
     ds = wkw.Dataset.open(
         path.join(info.dataset_path, info.layer_name, str(info.mag)), header
     )
-    logging.debug("ds.header.block_type: {}".format(ds.header.block_type))
     return ds
 
 
-def open_wkw(info, lock=None, block_type=None):
+def open_wkw(info, lock=None, **kwargs):
     if lock is None:
-        return _open_wkw(info, block_type)
-    else:
-        with lock:
-            return _open_wkw(info, block_type)
+        # Create dummy lock
+        lock = Lock()
+
+    with lock:
+        return _open_wkw(info, **kwargs)
 
 
 def open_knossos(info):


### PR DESCRIPTION
This PR adds multi-channel support for cubing tiff data.

I don't know whether dm3/dm4 supports multi-channel data (and whether we have sample data), which is why I didn't add multi-channel support for these formats.

Downsampling still only supports one channel. I created a follow-up issue for that: https://github.com/scalableminds/webknossos-cuber/issues/36