### PR TITLE
Don't use f string, making wkcuber python 3.5 compatible

### DIFF
--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -61,9 +61,13 @@ def find_source_filenames(source_path):
     source_files = list(
         find_files(path.join(source_path, "*"), image_reader.readers.keys())
     )
-    assert (
-        len(source_files) > 0
-    ), "No image files found in path " + source_path + ". Supported suffixes are " + str(image_reader.readers.keys()) + "."
+    assert len(source_files) > 0, (
+        "No image files found in path "
+        + source_path
+        + ". Supported suffixes are "
+        + str(image_reader.readers.keys())
+        + "."
+    )
     source_files.sort()
     return source_files
 

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -63,7 +63,7 @@ def find_source_filenames(source_path):
     )
     assert (
         len(source_files) > 0
-    ), f"No image files found in path {source_path}. Supported suffixes are {str(image_reader.readers.keys())}."
+    ), "No image files found in path " + source_path + ". Supported suffixes are " + str(image_reader.readers.keys()) + "."
     source_files.sort()
     return source_files
 


### PR DESCRIPTION
Using an f-string made this lib incompatible with python 3.5. We still use python 3.5 `segmentation-tools`, so it would be nice to restore python 3.5 compatibility.