### PR TITLE
Fix missing last slice in tiled cubing

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,3 +18,12 @@ def test_get_regular_chunks():
     assert len(target) == 6
     assert list(target[0]) == list(range(0, 8))
     assert list(target[-1]) == list(range(40, 48))
+
+
+def test_get_regular_chunks_max_inclusive():
+    target = list(get_regular_chunks(4, 44, 1))
+
+    assert len(target) == 41
+    assert list(target[0]) == list(range(4, 5))
+    # The last chunk should include 44
+    assert list(target[-1]) == list(range(44, 45))

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -62,10 +62,10 @@ def get_chunks(arr, chunk_size):
     for i in range(0, len(arr), chunk_size):
         yield arr[i : i + chunk_size]
 
-
+# min_z and max_z are both inclusive
 def get_regular_chunks(min_z, max_z, chunk_size):
     i = floor(min_z / chunk_size) * chunk_size
-    while i < ceil(max_z / chunk_size) * chunk_size:
+    while i < ceil((max_z + 1) / chunk_size) * chunk_size:
         yield range(i, i + chunk_size)
         i += chunk_size
 

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -62,6 +62,7 @@ def get_chunks(arr, chunk_size):
     for i in range(0, len(arr), chunk_size):
         yield arr[i : i + chunk_size]
 
+
 # min_z and max_z are both inclusive
 def get_regular_chunks(min_z, max_z, chunk_size):
     i = floor(min_z / chunk_size) * chunk_size


### PR DESCRIPTION
Changes get_regular_chunks to treat min and max as both inclusive. Fixes #42.