### PR TITLE
Fix cubing stacks with more 933120000 pixels

### DIFF
--- a/wkcuber/image_readers.py
+++ b/wkcuber/image_readers.py
@@ -6,6 +6,8 @@ from PIL import Image
 from .vendor.dm3 import DM3
 from .vendor.dm4 import DM4File
 
+# Disable PIL's maximum image limit.
+Image.MAX_IMAGE_PIXELS = None
 
 class PillowImageReader:
     def read_array(self, file_name, dtype):

--- a/wkcuber/image_readers.py
+++ b/wkcuber/image_readers.py
@@ -9,6 +9,7 @@ from .vendor.dm4 import DM4File
 # Disable PIL's maximum image limit.
 Image.MAX_IMAGE_PIXELS = None
 
+
 class PillowImageReader:
     def read_array(self, file_name, dtype):
         this_layer = np.array(Image.open(file_name), np.dtype(dtype))


### PR DESCRIPTION
Also see https://stackoverflow.com/questions/51152059/pillow-in-python-wont-let-me-open-image. I disabled the check completely, because I think we are big boys.