### PR TITLE
Fix python minor version to 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 ENV LZ4_VERSION=1.8.1.2
 


### PR DESCRIPTION
`3.6` is also fine, but we should fix it for now, I guess.