### PR TITLE
Fix downsampling for non uint8 data

### DIFF
--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -8,6 +8,7 @@ from wkcuber.downsampling import (
 )
 import wkw
 from wkcuber.utils import WkwDatasetInfo, open_wkw
+from wkcuber.downsampling import _mode
 import shutil
 
 WKW_CUBE_SIZE = 1024
@@ -26,12 +27,23 @@ def test_downsample_cube():
     buffer = np.zeros((CUBE_EDGE_LEN,) * 3, dtype=np.uint8)
     buffer[:, :, :] = np.arange(0, CUBE_EDGE_LEN)
 
-    output = downsample_cube(buffer, (2, 2, 2), InterpolationModes.MEDIAN)
+    output = downsample_cube(buffer, (2, 2, 2), InterpolationModes.MODE)
 
     assert output.shape == (CUBE_EDGE_LEN // 2,) * 3
     assert buffer[0, 0, 0] == 0
     assert buffer[0, 0, 1] == 1
     assert np.all(output[:, :, :] == np.arange(0, CUBE_EDGE_LEN, 2))
+
+def test_downsample_mode():
+
+    a = np.array([[1, 3, 4, 2, 2, 7],
+                  [5, 2, 2, 1, 4, 1],
+                  [3, 3, 2, 2, 1, 1]])
+
+    result = _mode(a)
+    expected_result = np.array([1, 3, 2, 2, 1, 1])
+
+    assert np.all(result == expected_result)
 
 
 def test_cube_addresses():

--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -94,7 +94,6 @@ if __name__ == "__main__":
         args.layer_name,
         Mag(1),
         Mag(args.max_mag),
-        args.dtype,
         "default",
         DEFAULT_EDGE_LEN,
         args.jobs,

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -186,7 +186,6 @@ def downsample_cube_job(
         with open_wkw(source_wkw_info) as source_wkw:
             num_channels = source_wkw.header.num_channels
             source_dtype = source_wkw.header.voxel_type
-            target_wkw_info.dtype = source_dtype
             with open_wkw(
                 target_wkw_info,
                 pool_get_lock(),
@@ -410,7 +409,10 @@ def downsample_mag(
         interpolation_mode = InterpolationModes[interpolation_mode.upper()]
 
     source_wkw_info = WkwDatasetInfo(path, layer_name, None, source_mag.to_layer_name())
-    target_wkw_info = WkwDatasetInfo(path, layer_name, None, target_mag.to_layer_name())
+    with open_wkw(source_wkw_info) as source:
+        target_wkw_info = WkwDatasetInfo(
+            path, layer_name, source.header.voxel_type, target_mag.to_layer_name()
+        )
     downsample(
         source_wkw_info,
         target_wkw_info,

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -185,6 +185,8 @@ def downsample_cube_job(
 
         with open_wkw(source_wkw_info) as source_wkw:
             num_channels = source_wkw.header.num_channels
+            source_dtype = source_wkw.header.voxel_type
+            target_wkw_info.dtype = source_dtype
             with open_wkw(
                 target_wkw_info,
                 pool_get_lock(),
@@ -195,7 +197,7 @@ def downsample_cube_job(
                     source_wkw.header.file_len * source_wkw.header.block_len
                 )
                 shape = (num_channels,) + (wkw_cubelength,) * 3
-                file_buffer = np.zeros(shape, target_wkw.header.voxel_type)
+                file_buffer = np.zeros(shape, source_dtype)
                 tile_length = cube_edge_len
                 tile_count_per_dim = wkw_cubelength // tile_length
                 assert (

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -360,14 +360,14 @@ def _mode(x):
     slices = [slice(None)] * ndim
     slices[axis] = slice(1, None)
     # Reshape and compute final counts
-    counts = counts.reshape(shape).transpose(transpose)[slices] + 1
+    counts = counts.reshape(shape).transpose(transpose)[tuple(slices)] + 1
 
     # Find maximum counts and return modals/counts
     slices = [slice(None, i) for i in sort.shape]
     del slices[axis]
     index = np.ogrid[slices]
     index.insert(axis, np.argmax(counts, axis=axis))
-    return sort[index]
+    return sort[tuple(index)]
 
 
 def downsample_cube(cube_buffer, factors, interpolation_mode):

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -21,7 +21,10 @@ KnossosDatasetInfo = namedtuple("KnossosDatasetInfo", ("dataset_path", "dtype"))
 
 
 def _open_wkw(info, **kwargs):
-    header = wkw.Header(np.dtype(info.dtype), **kwargs)
+    if info.dtype is not None:
+        header = wkw.Header(np.dtype(info.dtype), **kwargs)
+    else:
+        header = None
     ds = wkw.Dataset.open(
         path.join(info.dataset_path, info.layer_name, str(info.mag)), header
     )


### PR DESCRIPTION
This PR adds a faster implementation of the mode interpolation mode.
In addition, the dtype argument is not required anymore, which hopefully prevents further misuse.
The dtype is inferred from the input data instead.

closes #61 