### PR TITLE
Integrate clustertools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ python -m wkcuber.compress --layer_name segmentation data/target data/target_com
 python -m wkcuber.metadata --name great_dataset --scale 11.24,11.24,25 data/target
 ```
 
+### Parallelization
+
+Most tasks can be configured to be executed in a parallelized manner. Via `--distribution_strategy` you can pass `multiprocessing` or `slurm`. The first can be further configured with `--jobs` and the latter via `--job_resources='{"mem": "10M"}'`. Use `--help` to get more information.
+
 ## Test data credits
 Excerpts for testing purposes have been sampled from:
 - Dow Jacobo Hossain Siletti Hudspeth (2018). **Connectomics of the zebrafish's lateral-line neuromast reveals wiring and miswiring in a simple microcircuit.** eLife. [DOI:10.7554/eLife.33988](https://elifesciences.org/articles/33988)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest
 wkw>=0.0.6
 requests
 black
+git+git://github.com/scalableminds/cluster_tools@master#egg=cluster_tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pytest
 wkw>=0.0.6
 requests
 black
-git+git://github.com/scalableminds/cluster_tools@master#egg=cluster_tools
+git+git://github.com/scalableminds/cluster_tools@v1.0#egg=cluster_tools

--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     )
 
     if not args.no_compress:
-        compress_mag_inplace(args.target_path, args.layer_name, Mag(1), args.jobs)
+        compress_mag_inplace(args.target_path, args.layer_name, Mag(1), args.jobs, args)
 
     downsample_mags(
         args.target_path,

--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -6,7 +6,7 @@ from .cubing import cubing, BLOCK_LEN
 from .downsampling import downsample_mags, DEFAULT_EDGE_LEN
 from .compress import compress_mag_inplace
 from .metadata import write_webknossos_metadata
-from .utils import add_verbose_flag, add_jobs_flag
+from .utils import add_verbose_flag, add_distribution_flags
 from .mag import Mag
 
 
@@ -66,7 +66,7 @@ def create_parser():
     )
 
     add_verbose_flag(parser)
-    add_jobs_flag(parser)
+    add_distribution_flags(parser)
 
     return parser
 
@@ -84,6 +84,7 @@ if __name__ == "__main__":
         args.dtype,
         args.batch_size,
         args.jobs,
+        args,
     )
 
     if not args.no_compress:

--- a/wkcuber/compress.py
+++ b/wkcuber/compress.py
@@ -72,7 +72,7 @@ def compress_file_job(source_path, target_path):
         raise exc
 
 
-def compress_mag(source_path, layer_name, target_path, mag: Mag, jobs):
+def compress_mag(source_path, layer_name, target_path, mag: Mag, jobs, args=None):
     if path.exists(path.join(target_path, layer_name, str(mag))):
         logging.error("Target path '{}' already exists".format(target_path))
         exit(1)
@@ -98,9 +98,9 @@ def compress_mag(source_path, layer_name, target_path, mag: Mag, jobs):
     logging.info("Mag {0} successfully compressed".format(str(mag)))
 
 
-def compress_mag_inplace(target_path, layer_name, mag: Mag, jobs):
+def compress_mag_inplace(target_path, layer_name, mag: Mag, jobs, args=None):
     compress_target_path = "{}.compress-{}".format(target_path, uuid4())
-    compress_mag(target_path, layer_name, compress_target_path, mag, jobs)
+    compress_mag(target_path, layer_name, compress_target_path, mag, jobs, args)
 
     shutil.rmtree(path.join(target_path, layer_name, str(mag)))
     shutil.move(
@@ -111,7 +111,7 @@ def compress_mag_inplace(target_path, layer_name, mag: Mag, jobs):
 
 
 def compress_mags(
-    source_path, layer_name, target_path=None, mags: List[Mag] = None, jobs=1
+    source_path, layer_name, target_path=None, mags: List[Mag] = None, jobs=1, args=None
 ):
     with_tmp_dir = target_path is None
     target_path = source_path + ".tmp" if with_tmp_dir else target_path
@@ -121,7 +121,7 @@ def compress_mags(
     mags.sort()
 
     for mag in mags:
-        compress_mag(source_path, layer_name, target_path, mag, jobs)
+        compress_mag(source_path, layer_name, target_path, mag, jobs, args)
 
     if with_tmp_dir:
         makedirs(path.join(source_path + ".bak", layer_name), exist_ok=True)
@@ -147,5 +147,10 @@ if __name__ == "__main__":
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     compress_mags(
-        args.source_path, args.layer_name, args.target_path, args.mag, int(args.jobs)
+        args.source_path,
+        args.layer_name,
+        args.target_path,
+        args.mag,
+        int(args.jobs),
+        args,
     )

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -52,10 +52,6 @@ def create_parser():
         default=BLOCK_LEN,
     )
 
-    parser.add_argument(
-        "--distribution_strategy", choices=["sequential", "slurm", "multiprocessing"]
-    )
-
     add_verbose_flag(parser)
     add_distribution_flags(parser)
 

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -25,7 +25,11 @@ def open_wkw(info, **kwargs):
     if info.dtype is not None:
         header = wkw.Header(np.dtype(info.dtype), **kwargs)
     else:
-        logging.warn("Discarding the following wkw header args, because dtype was not provided: {}".format(kwargs))
+        logging.warn(
+            "Discarding the following wkw header args, because dtype was not provided: {}".format(
+                kwargs
+            )
+        )
         header = None
     ds = wkw.Dataset.open(
         path.join(info.dataset_path, info.layer_name, str(info.mag)), header

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -21,10 +21,11 @@ WkwDatasetInfo = namedtuple(
 KnossosDatasetInfo = namedtuple("KnossosDatasetInfo", ("dataset_path", "dtype"))
 
 
-def _open_wkw(info, **kwargs):
+def open_wkw(info, **kwargs):
     if info.dtype is not None:
         header = wkw.Header(np.dtype(info.dtype), **kwargs)
     else:
+        logging.warn("Discarding the following wkw header args, because dtype was not provided: {}".format(kwargs))
         header = None
     ds = wkw.Dataset.open(
         path.join(info.dataset_path, info.layer_name, str(info.mag)), header
@@ -32,18 +33,9 @@ def _open_wkw(info, **kwargs):
     return ds
 
 
-def open_wkw(info, lock=None, **kwargs):
-    if lock is None:
-        # Create dummy lock
-        lock = Lock()
-
-    with lock:
-        return _open_wkw(info, **kwargs)
-
-
-def ensure_wkw(target_wkw_info, num_channels):
+def ensure_wkw(target_wkw_info, **kwargs):
     # Open will create the dataset if it doesn't exist yet
-    target_wkw = open_wkw(target_wkw_info, num_channels=num_channels)
+    target_wkw = open_wkw(target_wkw_info, **kwargs)
     target_wkw.close()
 
 

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -2,16 +2,17 @@ import time
 import wkw
 import numpy as np
 import logging
+import argparse
+import cluster_tools
+import json
 from glob import iglob
 from collections import namedtuple
 from multiprocessing import cpu_count, Lock
+import concurrent
 from concurrent.futures import ProcessPoolExecutor
 from os import path
 from platform import python_version
 from math import floor, ceil
-
-
-from .knossos import KnossosDataset, CUBE_EDGE_LEN
 
 
 WkwDatasetInfo = namedtuple(
@@ -38,6 +39,12 @@ def open_wkw(info, lock=None, **kwargs):
 
     with lock:
         return _open_wkw(info, **kwargs)
+
+
+def ensure_wkw(target_wkw_info, num_channels):
+    # Open will create the dataset if it doesn't exist yet
+    target_wkw = open_wkw(target_wkw_info, num_channels=num_channels)
+    target_wkw.close()
 
 
 def open_knossos(info):
@@ -74,48 +81,74 @@ def get_regular_chunks(min_z, max_z, chunk_size):
         i += chunk_size
 
 
-def add_jobs_flag(parser):
+def add_distribution_flags(parser):
     parser.add_argument(
-        "--jobs", "-j", help="Parallel jobs", type=int, default=cpu_count()
+        "--processes",
+        default=cpu_count(),
+        type=int,
+        help="Number of processes to be spawned",
+    )
+
+    parser.add_argument(
+        "--jobs",
+        "-j",
+        default=cpu_count(),
+        type=int,
+        help="Number of processes to be spawned. Synonym to --processes.",
+    )
+
+    parser.add_argument(
+        "--distribution_strategy",
+        default="multiprocessing",
+        choices=["slurm", "multiprocessing"],
+        help="Strategy to distribute the task across CPUs or nodes.",
+    )
+
+    parser.add_argument(
+        "--job_resources",
+        default=None,
+        help='Necessary when using slurm as distribution strategy. Should be a JSON string (e.g., --job_resources=\'{"mem": "10M"}\')',
     )
 
 
-def pool_init(lock):
-    global process_pool_lock
-    process_pool_lock = lock
+def get_executor_for_args(args):
+    if args is None:
+        # For backwards compatibility with code from other packages
+        # we allow args to be None. In this case we are defaulting
+        # to these values:
+        args.distribution_strategy = "multiprocessing"
+        args.processes = cpu_count()
 
+    executor = None
 
-def pool_get_lock():
-    global process_pool_lock
-    try:
-        return process_pool_lock
-    except NameError:
-        return None
-
-
-class ParallelExecutor:
-    def __init__(self, jobs):
-        self.lock = Lock()
-        if python_version() >= "3.7.0":
-            self.exec = ProcessPoolExecutor(
-                jobs, initializer=pool_init, initargs=(self.lock,)
+    if args.distribution_strategy == "multiprocessing":
+        if args.processes is None and args.jobs is None:
+            raise argparse.ArgumentTypeError(
+                "Number of processes (--processes) has to be provided when using multiprocessing as distribution strategy."
             )
-        else:
-            self.exec = ProcessPoolExecutor(jobs)
-        self.futures = []
 
-    def submit(self, fn, *args):
-        future = self.exec.submit(fn, *args)
-        self.futures.append(future)
-        return future
+        executor = cluster_tools.get_executor("multiprocessing", args.processes)
+        processes = args.processes if args.processes is not None else args.jobs
+        logging.info("Using pool of {} workers.".format(args.processes))
+    elif args.distribution_strategy == "slurm":
+        if args.job_resources is None:
+            raise argparse.ArgumentTypeError(
+                'Job resources (--job_resources) has to be provided when using slurm as distribution strategy. Example: --job_resources=\'{"mem": "10M"}\''
+            )
 
-    def __enter__(self):
-        self.exec.__enter__()
-        return self
+        executor = cluster_tools.get_executor(
+            "slurm",
+            debug=True,
+            keep_logs=True,
+            job_resources=json.loads(args.job_resources),
+        )
+        logging.info("Using slurm cluster.")
+    else:
+        logging.error(
+            "Unknown distribution strategy: {}".format(args.distribution_strategy)
+        )
 
-    def __exit__(self, type, value, tb):
-        [f.result() for f in self.futures]
-        self.exec.__exit__(type, value, tb)
+    return executor
 
 
 times = {}
@@ -128,3 +161,10 @@ def time_start(identifier):
 def time_stop(identifier):
     _time = times.pop(identifier)
     logging.debug("{} took {:.8f}s".format(identifier, time.time() - _time))
+
+
+# Waits for all futures to complete and raises an exception
+# as soon as a future resolves with an error.
+def wait_and_ensure_success(futures):
+    for fut in concurrent.futures.as_completed(futures):
+        fut.result()

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -14,12 +14,11 @@ from os import path
 from platform import python_version
 from math import floor, ceil
 
-
 WkwDatasetInfo = namedtuple(
     "WkwDatasetInfo", ("dataset_path", "layer_name", "dtype", "mag")
 )
 KnossosDatasetInfo = namedtuple("KnossosDatasetInfo", ("dataset_path", "dtype"))
-
+FallbackArgs = namedtuple("FallbackArgs", ("distribution_strategy", "jobs"))
 
 def open_wkw(info, **kwargs):
     if info.dtype is not None:
@@ -105,7 +104,7 @@ def get_executor_for_args(args):
         # For backwards compatibility with code from other packages
         # we allow args to be None. In this case we are defaulting
         # to these values:
-        args = {"distribution_strategy": "multiprocessing", "jobs": cpu_count()}
+        args = FallbackArgs("multiprocessing", cpu_count())
 
     executor = None
 

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -14,6 +14,8 @@ from os import path
 from platform import python_version
 from math import floor, ceil
 
+from .knossos import KnossosDataset, CUBE_EDGE_LEN
+
 WkwDatasetInfo = namedtuple(
     "WkwDatasetInfo", ("dataset_path", "layer_name", "dtype", "mag")
 )

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -83,18 +83,11 @@ def get_regular_chunks(min_z, max_z, chunk_size):
 
 def add_distribution_flags(parser):
     parser.add_argument(
-        "--processes",
-        default=cpu_count(),
-        type=int,
-        help="Number of processes to be spawned",
-    )
-
-    parser.add_argument(
         "--jobs",
         "-j",
         default=cpu_count(),
         type=int,
-        help="Number of processes to be spawned. Synonym to --processes.",
+        help="Number of processes to be spawned.",
     )
 
     parser.add_argument(
@@ -117,19 +110,18 @@ def get_executor_for_args(args):
         # we allow args to be None. In this case we are defaulting
         # to these values:
         args.distribution_strategy = "multiprocessing"
-        args.processes = cpu_count()
+        args.jobs = cpu_count()
 
     executor = None
 
     if args.distribution_strategy == "multiprocessing":
-        if args.processes is None and args.jobs is None:
+        if args.jobs is None:
             raise argparse.ArgumentTypeError(
-                "Number of processes (--processes) has to be provided when using multiprocessing as distribution strategy."
+                "Number of processes (--jobs) has to be provided when using multiprocessing as distribution strategy."
             )
 
-        executor = cluster_tools.get_executor("multiprocessing", args.processes)
-        processes = args.processes if args.processes is not None else args.jobs
-        logging.info("Using pool of {} workers.".format(args.processes))
+        executor = cluster_tools.get_executor("multiprocessing", args.jobs)
+        logging.info("Using pool of {} workers.".format(args.jobs))
     elif args.distribution_strategy == "slurm":
         if args.job_resources is None:
             raise argparse.ArgumentTypeError(

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -111,11 +111,6 @@ def get_executor_for_args(args):
     executor = None
 
     if args.distribution_strategy == "multiprocessing":
-        if args.jobs is None:
-            raise argparse.ArgumentTypeError(
-                "Number of processes (--jobs) has to be provided when using multiprocessing as distribution strategy."
-            )
-
         executor = cluster_tools.get_executor("multiprocessing", args.jobs)
         logging.info("Using pool of {} workers.".format(args.jobs))
     elif args.distribution_strategy == "slurm":

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -105,8 +105,10 @@ def get_executor_for_args(args):
         # For backwards compatibility with code from other packages
         # we allow args to be None. In this case we are defaulting
         # to these values:
-        args.distribution_strategy = "multiprocessing"
-        args.jobs = cpu_count()
+        args = {
+            "distribution_strategy": "multiprocessing",
+            "jobs": cpu_count()
+        }
 
     executor = None
 

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -20,6 +20,7 @@ WkwDatasetInfo = namedtuple(
 KnossosDatasetInfo = namedtuple("KnossosDatasetInfo", ("dataset_path", "dtype"))
 FallbackArgs = namedtuple("FallbackArgs", ("distribution_strategy", "jobs"))
 
+
 def open_wkw(info, **kwargs):
     if info.dtype is not None:
         header = wkw.Header(np.dtype(info.dtype), **kwargs)

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -105,10 +105,7 @@ def get_executor_for_args(args):
         # For backwards compatibility with code from other packages
         # we allow args to be None. In this case we are defaulting
         # to these values:
-        args = {
-            "distribution_strategy": "multiprocessing",
-            "jobs": cpu_count()
-        }
+        args = {"distribution_strategy": "multiprocessing", "jobs": cpu_count()}
 
     executor = None
 


### PR DESCRIPTION
Most notable, the executor won't catch failed futures automatically, as the old `ParallelExecutor` did. This is according to the common concurrent.futures.executor interface. I added an explicit `wait_and_ensure_success` call to handle errors.

Also, the locking logic was removed in favor of ensuring the existence of a dataset before distributing the jobs.

I tried to not change the interface of most of the functions (e.g., `cubing(...)`)  so that external libraries don't break. For that reason, the code around `args` is a bit verbose.