### PR TITLE
Remove obsolete jobs arg and accept 'processes' arg when handling distribution args

### DIFF
--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -83,12 +83,11 @@ if __name__ == "__main__":
         args.layer_name,
         args.dtype,
         args.batch_size,
-        args.jobs,
         args,
     )
 
     if not args.no_compress:
-        compress_mag_inplace(args.target_path, args.layer_name, Mag(1), args.jobs, args)
+        compress_mag_inplace(args.target_path, args.layer_name, Mag(1), args)
 
     downsample_mags(
         args.target_path,
@@ -97,7 +96,6 @@ if __name__ == "__main__":
         Mag(args.max_mag),
         "default",
         DEFAULT_EDGE_LEN,
-        args.jobs,
         not args.no_compress,
     )
 

--- a/wkcuber/compress.py
+++ b/wkcuber/compress.py
@@ -72,7 +72,7 @@ def compress_file_job(source_path, target_path):
         raise exc
 
 
-def compress_mag(source_path, layer_name, target_path, mag: Mag, jobs, args=None):
+def compress_mag(source_path, layer_name, target_path, mag: Mag, args=None):
     if path.exists(path.join(target_path, layer_name, str(mag))):
         logging.error("Target path '{}' already exists".format(target_path))
         exit(1)
@@ -98,9 +98,9 @@ def compress_mag(source_path, layer_name, target_path, mag: Mag, jobs, args=None
     logging.info("Mag {0} successfully compressed".format(str(mag)))
 
 
-def compress_mag_inplace(target_path, layer_name, mag: Mag, jobs, args=None):
+def compress_mag_inplace(target_path, layer_name, mag: Mag, args=None):
     compress_target_path = "{}.compress-{}".format(target_path, uuid4())
-    compress_mag(target_path, layer_name, compress_target_path, mag, jobs, args)
+    compress_mag(target_path, layer_name, compress_target_path, mag, args)
 
     shutil.rmtree(path.join(target_path, layer_name, str(mag)))
     shutil.move(
@@ -111,7 +111,7 @@ def compress_mag_inplace(target_path, layer_name, mag: Mag, jobs, args=None):
 
 
 def compress_mags(
-    source_path, layer_name, target_path=None, mags: List[Mag] = None, jobs=1, args=None
+    source_path, layer_name, target_path=None, mags: List[Mag] = None, args=None
 ):
     with_tmp_dir = target_path is None
     target_path = source_path + ".tmp" if with_tmp_dir else target_path
@@ -121,7 +121,7 @@ def compress_mags(
     mags.sort()
 
     for mag in mags:
-        compress_mag(source_path, layer_name, target_path, mag, jobs, args)
+        compress_mag(source_path, layer_name, target_path, mag, args)
 
     if with_tmp_dir:
         makedirs(path.join(source_path + ".bak", layer_name), exist_ok=True)
@@ -151,6 +151,5 @@ if __name__ == "__main__":
         args.layer_name,
         args.target_path,
         args.mag,
-        int(args.jobs),
         args,
     )

--- a/wkcuber/compress.py
+++ b/wkcuber/compress.py
@@ -146,10 +146,4 @@ if __name__ == "__main__":
     args = create_parser().parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
-    compress_mags(
-        args.source_path,
-        args.layer_name,
-        args.target_path,
-        args.mag,
-        args,
-    )
+    compress_mags(args.source_path, args.layer_name, args.target_path, args.mag, args)

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -144,9 +144,7 @@ def cubing_job(
                 raise exc
 
 
-def cubing(
-    source_path, target_path, layer_name, dtype, batch_size, args=None
-) -> dict:
+def cubing(source_path, target_path, layer_name, dtype, batch_size, args=None) -> dict:
 
     target_wkw_info = WkwDatasetInfo(target_path, layer_name, dtype, 1)
     source_files = find_source_filenames(source_path)

--- a/wkcuber/cubing.py
+++ b/wkcuber/cubing.py
@@ -145,7 +145,7 @@ def cubing_job(
 
 
 def cubing(
-    source_path, target_path, layer_name, dtype, batch_size, jobs, args=None
+    source_path, target_path, layer_name, dtype, batch_size, args=None
 ) -> dict:
 
     target_wkw_info = WkwDatasetInfo(target_path, layer_name, dtype, 1)
@@ -198,6 +198,5 @@ if __name__ == "__main__":
         args.layer_name,
         args.dtype,
         args.batch_size,
-        args.jobs,
         args=args,
     )

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -114,7 +114,6 @@ def downsample(
     target_mag: Mag,
     interpolation_mode,
     cube_edge_len,
-    jobs,
     compress,
     args=None,
 ):
@@ -401,7 +400,6 @@ def downsample_mag(
     target_mag: Mag,
     interpolation_mode="default",
     cube_edge_len=DEFAULT_EDGE_LEN,
-    jobs=1,
     compress=False,
     args=None,
 ):
@@ -426,7 +424,6 @@ def downsample_mag(
         target_mag,
         interpolation_mode,
         cube_edge_len,
-        jobs,
         compress,
         args,
     )
@@ -439,7 +436,6 @@ def downsample_mags(
     max_mag: Mag,
     interpolation_mode,
     cube_edge_len,
-    jobs,
     compress,
     args=None,
 ):
@@ -453,7 +449,6 @@ def downsample_mags(
             target_mag,
             interpolation_mode,
             cube_edge_len,
-            jobs,
             compress,
             args,
         )
@@ -478,7 +473,6 @@ if __name__ == "__main__":
             anisotropic_target_mag,
             args.interpolation_mode,
             args.buffer_cube_size,
-            args.jobs,
             args.compress,
             args,
         )
@@ -490,7 +484,6 @@ if __name__ == "__main__":
             max_mag,
             args.interpolation_mode,
             args.buffer_cube_size,
-            args.jobs,
             args.compress,
             args,
         )

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -112,8 +112,11 @@ def get_executor_for_args(args):
     executor = None
 
     if args.distribution_strategy == "multiprocessing":
-        executor = cluster_tools.get_executor("multiprocessing", args.jobs)
-        logging.info("Using pool of {} workers.".format(args.jobs))
+        # Also accept "processes" instead of job to be compatible with segmentation-tools.
+        # In the long run, the args should be unified and provided by the clustertools.
+        jobs = args.jobs if "jobs" in args else args.processes
+        executor = cluster_tools.get_executor("multiprocessing", jobs)
+        logging.info("Using pool of {} workers.".format(jobs))
     elif args.distribution_strategy == "slurm":
         if args.job_resources is None:
             raise argparse.ArgumentTypeError(

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -114,7 +114,13 @@ def get_executor_for_args(args):
     if args.distribution_strategy == "multiprocessing":
         # Also accept "processes" instead of job to be compatible with segmentation-tools.
         # In the long run, the args should be unified and provided by the clustertools.
-        jobs = args.jobs if "jobs" in args else args.processes
+        if "jobs" in args:
+            jobs = args.jobs
+        elif "processes" in args:
+            jobs = args.processes
+        else:
+            jobs = cpu_count()
+
         executor = cluster_tools.get_executor("multiprocessing", jobs)
         logging.info("Using pool of {} workers.".format(jobs))
     elif args.distribution_strategy == "slurm":


### PR DESCRIPTION
This PR cleans up the obsolete jobs arg which was passed around unnecessarily (the get_executor function inspects the whole args to pick the right strategy, anyway). Additionally, get_executor also accepts  `processes` in addition to `jobs` since other libraries (i.e., cuber) use that internally. In the long run, the argument handling should be provided by the clustertools, too, to unify this handling.