### PR TITLE
Fix get_executor invocation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="wkcuber",
     packages=find_packages(exclude=("tests",)),
-    version="0.2.3",
+    version="0.2.4",
     install_requires=["scipy", "numpy", "pillow", "pyyaml", "wkw"],
     description="A cubing tool for webKnossos",
     author="Norman Rzepka",

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -125,7 +125,7 @@ def get_executor_for_args(args):
         else:
             jobs = cpu_count()
 
-        executor = cluster_tools.get_executor("multiprocessing", jobs)
+        executor = cluster_tools.get_executor("multiprocessing", max_workers=jobs)
         logging.info("Using pool of {} workers.".format(jobs))
     elif args.distribution_strategy == "slurm":
         if args.job_resources is None:


### PR DESCRIPTION
The argument max_workers arg has to be named and not positional.