### PR TITLE
Set default wkw file name

### DIFF
--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -75,12 +75,6 @@ def create_parser():
 
 if __name__ == "__main__":
     args = create_parser().parse_args()
-    
-    if args.name == None:
-        if os.path.isdir(args.source_path):
-	    args.name == os.path.basename(args.source_path)
-	else:
-	    args.name = os.path.basename(os.path.dirname(args.source_path))
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)

--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser
 
 import logging
-import os
 
 from .cubing import cubing, BLOCK_LEN
 from .downsampling import downsample_mags, downsample_mags_anisotropic, DEFAULT_EDGE_LEN

--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 
 import logging
+import os
 
 from .cubing import cubing, BLOCK_LEN
 from .downsampling import downsample_mags, downsample_mags_anisotropic, DEFAULT_EDGE_LEN
@@ -74,6 +75,12 @@ def create_parser():
 
 if __name__ == "__main__":
     args = create_parser().parse_args()
+    
+    if args.name == None:
+        if os.path.isdir(args.source_path):
+	    args.name == os.path.basename(args.source_path)
+	else:
+	    args.name = os.path.basename(os.path.dirname(args.source_path))
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -69,6 +69,8 @@ def write_webknossos_metadata(
     compute_max_id=False,
     exact_bounding_box: Optional[dict] = None,
 ):
+    if name == None:
+        name = path.basename(dataset_path)
 
     # Generate a metadata file for webKnossos
     # Currently includes no source of information for team


### PR DESCRIPTION
This PR addresses #76.

I decided to take the directory name as the `name` if a `name` is not provided. I decided to make the change in `metadata.py/write_webknossos_metadata` because this will directly fix it as well when `wkcuber` is used as a library e.g. `segmentation-tools`.