### PR TITLE
auto-bump version number according to git tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN pip install -r requirements.txt
 COPY wkcuber /app/wkcuber
 COPY tests /app/tests
 
+COPY .git /app/.git
 RUN python setup.py install
+RUN rm -r /app/.git
 
 ENTRYPOINT [ "python", "-m" ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup, find_packages
 setup(
     name="wkcuber",
     packages=find_packages(exclude=("tests",)),
-    version="0.2.14",
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     install_requires=["scipy", "numpy", "pillow", "pyyaml", "wkw", "cluster_tools>=1.19"],
     description="A cubing tool for webKnossos",
     author="Norman Rzepka",


### PR DESCRIPTION
see https://github.com/scalableminds/cluster_tools/pull/52 which does the same for cluster_tools