### PR TITLE
Make scale parameter required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,10 @@ jobs:
           command: tests/scripts/simple_tiff_cubing_no_compression.sh
 
       - run:
+          name: Test metadata generation
+          command: tests/scripts/meta_generation.sh
+
+      - run:
           name: Test KNOSSOS conversion
           command: tests/scripts/knossos_conversion.sh
 
@@ -88,10 +92,6 @@ jobs:
       - run:
           name: Test in-place compression
           command: tests/scripts/in_place_compression.sh
-
-      - run:
-          name: Test metadata generation
-          command: tests/scripts/meta_generation.sh
 
       - run:
           name: Remove reference magnification data

--- a/tests/scripts/anisotropic_downsampling.sh
+++ b/tests/scripts/anisotropic_downsampling.sh
@@ -37,7 +37,6 @@ docker run \
   --max 16 \
   --buffer_cube_size 128 \
   --layer_name color \
-  --scale 11.24,11.24,25 \
   /testoutput/tiff
 [ -d testoutput/tiff/color/8-8-2 ]
 [ -d testoutput/tiff/color/16-16-4 ]

--- a/tests/scripts/simple_anisotropic_tiff_cubing.sh
+++ b/tests/scripts/simple_anisotropic_tiff_cubing.sh
@@ -10,7 +10,6 @@ docker run \
   --batch_size 8 \
   --layer_name color \
   --max 8 \
-  --scale 11.24,25,11.24 \
   --name awesome_data \
   /testdata/tiff /testoutput/tiff3
 [ -d testoutput/tiff3/color ]

--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -5,7 +5,7 @@ from .downsampling import (
     DEFAULT_EDGE_LEN,
 )
 from .compress import compress_mag_inplace
-from .metadata import write_webknossos_metadata
+from .metadata import write_webknossos_metadata, refresh_metadata
 from .utils import add_isotropic_flag, setup_logging, add_scale_flag
 from .mag import Mag
 
@@ -50,6 +50,14 @@ if __name__ == "__main__":
         args,
     )
 
+    write_webknossos_metadata(
+        args.target_path,
+        args.name,
+        scale,
+        compute_max_id=False,
+        exact_bounding_box=bounding_box,
+    )
+
     if not args.no_compress:
         compress_mag_inplace(args.target_path, args.layer_name, Mag(1), args)
 
@@ -78,10 +86,4 @@ if __name__ == "__main__":
             args,
         )
 
-    write_webknossos_metadata(
-        args.target_path,
-        args.name,
-        scale,
-        compute_max_id=False,
-        exact_bounding_box=bounding_box,
-    )
+    refresh_metadata(args.target_path)

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -21,7 +21,6 @@ from .utils import (
     get_executor_for_args,
     wait_and_ensure_success,
     add_isotropic_flag,
-    add_scale_flag,
     setup_logging,
 )
 
@@ -109,7 +108,6 @@ def create_parser():
         action="store_true",
     )
 
-    add_scale_flag(parser)
     add_verbose_flag(parser)
     add_isotropic_flag(parser)
     add_distribution_flags(parser)
@@ -604,9 +602,7 @@ if __name__ == "__main__":
 
     from_mag = Mag(args.from_mag)
     max_mag = Mag(args.max)
-    scale = (
-        [float(x) for x in args.scale.split(",")] if hasattr(args, "scale") else None
-    )
+
     if args.anisotropic_target_mag:
         anisotropic_target_mag = Mag(args.anisotropic_target_mag)
 
@@ -621,16 +617,15 @@ if __name__ == "__main__":
             args,
         )
     elif not args.isotropic:
-        if scale is None:
-            try:
-                scale = read_datasource_properties(args.path)["scale"]
-            except Exception as exc:
-                logging.error(
-                    "Could not determine scale which is necessary "
-                    "to find target magnifications for anisotropic downsampling. "
-                    "Does the provided dataset have a datasource-properties.json file?"
-                )
-                raise exc
+        try:
+            scale = read_datasource_properties(args.path)["scale"]
+        except Exception as exc:
+            logging.error(
+                "Could not determine scale which is necessary "
+                "to find target magnifications for anisotropic downsampling. "
+                "Does the provided dataset have a datasource-properties.json file?"
+            )
+            raise exc
 
         downsample_mags_anisotropic(
             args.path,

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -66,7 +66,7 @@ def add_scale_flag(parser):
         "--scale",
         "-s",
         help="Scale of the dataset (e.g. 11.2,11.2,25). This is the size of one voxel in nm.",
-        default="1,1,1",
+        required=True,
     )
 
 


### PR DESCRIPTION
...and remove scale parameter from downsampling tool.

- a default of 1,1,1 for the scale is almost never correct. the most likely scenario is that you forget to set the parameter and then your downsampling is isotropic. so, you have to fix the parameter in the dataset and downsample again
- the scale parameter for the downsampling tool shouldn't be necessary. the datasource-properties.json should always contain that scale