### PR TITLE
fixed float/double to float32, float64 conversion

### DIFF
--- a/tests/scripts/simple_anisotropic_tiff_cubing.sh
+++ b/tests/scripts/simple_anisotropic_tiff_cubing.sh
@@ -10,6 +10,7 @@ docker run \
   --batch_size 8 \
   --layer_name color \
   --max 8 \
+  --scale "11.24,11.24,25"\
   --name awesome_data \
   /testdata/tiff /testoutput/tiff3
 [ -d testoutput/tiff3/color ]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -17,9 +17,9 @@ def test_element_class_convertion():
     prediction_wkw_info = WkwDatasetInfo(
         test_wkw_path, prediction_layer_name, np.float32, 1
     )
-    ensure_wkw(prediction_wkw_info, num_channels=1)
+    ensure_wkw(prediction_wkw_info, num_channels=3)
 
-    write_costum_layer(test_wkw_path, "prediction", np.float32, num_channels=1)
+    write_custom_layer(test_wkw_path, "prediction", np.float32, num_channels=3)
     write_webknossos_metadata(
         test_wkw_path,
         "test_metadata",
@@ -27,8 +27,8 @@ def test_element_class_convertion():
         compute_max_id=True,
         exact_bounding_box={"topLeft": [0, 0, 0], "width": 4, "height": 4, "depth": 4},
     )
-    write_costum_layer(test_wkw_path, "segmentation", np.float64, num_channels=1)
-    write_costum_layer(test_wkw_path, "color", np.uint8, num_channels=3)
+    write_custom_layer(test_wkw_path, "segmentation", np.float64, num_channels=1)
+    write_custom_layer(test_wkw_path, "color", np.uint8, num_channels=3)
 
     refresh_metadata(test_wkw_path)
 
@@ -54,7 +54,7 @@ def check_element_class_of_layer(
     assert converted_dtype == expected_dtype
 
 
-def write_costum_layer(target_path, layer_name, dtype, num_channels):
+def write_custom_layer(target_path, layer_name, dtype, num_channels):
     data = (
         np.arange(4 * 4 * 4 * num_channels)
         .reshape((num_channels, 4, 4, 4))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,70 @@
+import numpy as np
+import os
+
+from wkcuber.cubing import ensure_wkw
+from wkcuber.utils import WkwDatasetInfo, open_wkw
+from wkcuber.metadata import (
+    write_webknossos_metadata,
+    refresh_metadata,
+    read_datasource_properties,
+    read_metadata_for_layer,
+)
+
+
+def test_element_class_convertion():
+    test_wkw_path = os.path.join("testoutput", "test_metadata")
+    prediction_layer_name = "prediction"
+    prediction_wkw_info = WkwDatasetInfo(
+        test_wkw_path, prediction_layer_name, np.float32, 1
+    )
+    ensure_wkw(prediction_wkw_info, num_channels=1)
+
+    write_costum_layer(test_wkw_path, "prediction", np.float32, num_channels=1)
+    write_webknossos_metadata(
+        test_wkw_path,
+        "test_metadata",
+        [11.24, 11.24, 28],
+        compute_max_id=True,
+        exact_bounding_box={"topLeft": [0, 0, 0], "width": 4, "height": 4, "depth": 4},
+    )
+    write_costum_layer(test_wkw_path, "segmentation", np.float64, num_channels=1)
+    write_costum_layer(test_wkw_path, "color", np.uint8, num_channels=3)
+
+    refresh_metadata(test_wkw_path)
+
+    check_element_class_of_layer(test_wkw_path, "prediction", "float", np.float32)
+    check_element_class_of_layer(test_wkw_path, "segmentation", "double", np.float64)
+    check_element_class_of_layer(test_wkw_path, "color", "uint24", np.uint8)
+
+
+def check_element_class_of_layer(
+    test_wkw_path, layer_name, expected_element_class, expected_dtype
+):
+    datasource_properties = read_datasource_properties(test_wkw_path)
+    layer_to_check = None
+    for layer in datasource_properties["dataLayers"]:
+        if layer["name"] == layer_name:
+            layer_to_check = layer
+
+    assert (
+        layer_to_check
+    ), f"Did not find layer {layer_name} in datasource_properties.json."
+    assert layer_to_check["elementClass"] == expected_element_class
+    _, converted_dtype, _, _ = read_metadata_for_layer(test_wkw_path, layer_name)
+    assert converted_dtype == expected_dtype
+
+
+def write_costum_layer(target_path, layer_name, dtype, num_channels):
+    data = (
+        np.arange(4 * 4 * 4 * num_channels)
+        .reshape((num_channels, 4, 4, 4))
+        .astype(dtype)
+    )
+    prediction_wkw_info = WkwDatasetInfo(target_path, layer_name, dtype, 1)
+    ensure_wkw(prediction_wkw_info, num_channels=num_channels)
+    with open_wkw(prediction_wkw_info, num_channels=num_channels) as dataset:
+        dataset.write(off=(0, 0, 0), data=data)
+
+
+if __name__ == "__main__":
+    test_element_class_convertion()

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -133,7 +133,14 @@ def refresh_metadata(
 
 def convert_element_class_to_dtype(elementClass):
     default_dtype = np.uint8 if "uint" in elementClass else np.dtype(elementClass)
-    conversion_map = {"float": np.float32, "double": np.float64, "uint8": np.uint8, "uint16": np.uint16, "uint32": np.uint32, "uint64": np.uint64}
+    conversion_map = {
+        "float": np.float32,
+        "double": np.float64,
+        "uint8": np.uint8,
+        "uint16": np.uint16,
+        "uint32": np.uint32,
+        "uint64": np.uint64,
+    }
     return conversion_map.get(elementClass, default_dtype)
 
 
@@ -156,7 +163,14 @@ def read_metadata_for_layer(wkw_path, layer_name):
 
 
 def convert_dype_to_element_class(dtype):
-    element_class_to_dtype_map = {"float": np.float32, "double": np.float64, "uint8": np.uint8, "uint16": np.uint16, "uint32": np.uint32, "uint64": np.uint64}
+    element_class_to_dtype_map = {
+        "float": np.float32,
+        "double": np.float64,
+        "uint8": np.uint8,
+        "uint16": np.uint16,
+        "uint32": np.uint32,
+        "uint64": np.uint64,
+    }
     conversion_map = {v: k for k, v in element_class_to_dtype_map.items()}
     return conversion_map.get(dtype.type, str(dtype))
 

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -132,15 +132,9 @@ def refresh_metadata(
 
 
 def convert_element_class_to_dtype(elementClass):
-    convertion_map = {"float": np.float32, "double": np.float64}
-    known_numpy_types = ["uint8", "uint16", "uint32", "uint64"]
-    if elementClass in convertion_map.keys():
-        return convertion_map[elementClass]
-    else:
-        if "uint" in elementClass and elementClass not in known_numpy_types:
-            return np.uint8
-        else:
-            return np.dtype(elementClass)
+    default_dtype = np.uint8 if "uint" in elementClass else np.dtype(elementClass)
+    conversion_map = {"float": np.float32, "double": np.float64, "uint8": np.uint8, "uint16": np.uint16, "uint32": np.uint32, "uint64": np.uint64}
+    return conversion_map.get(elementClass, default_dtype)
 
 
 def read_metadata_for_layer(wkw_path, layer_name):
@@ -162,11 +156,9 @@ def read_metadata_for_layer(wkw_path, layer_name):
 
 
 def convert_dype_to_element_class(dtype):
-    convertion_map = {np.float32: "float", np.float64: "double"}
-    if dtype.type in convertion_map.keys():
-        return convertion_map[dtype.type]
-    else:
-        return str(dtype)
+    element_class_to_dtype_map = {"float": np.float32, "double": np.float64, "uint8": np.uint8, "uint16": np.uint16, "uint32": np.uint32, "uint64": np.uint64}
+    conversion_map = {v: k for k, v in element_class_to_dtype_map.items()}
+    return conversion_map.get(dtype.type, str(dtype))
 
 
 def detect_dtype(dataset_path, layer, mag: Mag = Mag(1)):


### PR DESCRIPTION
This PR fixes the bug described in #100. Additionally I fixed two more bugs. An argument was missing in the tests. `read_read_metadata_for_layer` could not read a layer with the `elementClass` of `uint24` which can be produced by writing a layer with dtype `uint8` and 3 channels. I fixed it by returning `uint8` when there is no `numpy-dtype` that matches `elementClass`. 


**Steps to test:**
       run the tests

**Issues**:
      fixes #100