### PR TITLE
Update metadata after downsampling

### DIFF
--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -8,7 +8,7 @@ from scipy.ndimage.interpolation import zoom
 from itertools import product
 from enum import Enum
 from .mag import Mag
-from .metadata import read_datasource_properties
+from .metadata import read_datasource_properties, refresh_metadata
 
 from .utils import (
     add_verbose_flag,
@@ -649,3 +649,5 @@ if __name__ == "__main__":
             not args.no_compress,
             args,
         )
+
+    refresh_metadata(args.path)

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -290,7 +290,9 @@ if __name__ == "__main__":
     setup_logging(args)
 
     if not args.refresh:
-        assert args.scale is not None, "The scale has to be specified when creating metadata for a dataset."
+        assert (
+            args.scale is not None
+        ), "The scale has to be specified when creating metadata for a dataset."
         assert (
             args.name is not None
         ), "Please provide a name via --name to create meta data."

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -36,7 +36,7 @@ def create_parser():
     )
     group.add_argument("--max_id", help="set max id of segmentation.", default=0)
 
-    add_scale_flag(parser)
+    add_scale_flag(parser, required=False)
     add_verbose_flag(parser)
 
     return parser
@@ -290,6 +290,7 @@ if __name__ == "__main__":
     setup_logging(args)
 
     if not args.refresh:
+        assert args.scale is not None, "The scale has to be specified when creating metadata for a dataset."
         assert (
             args.name is not None
         ), "Please provide a name via --name to create meta data."

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -61,12 +61,12 @@ def add_verbose_flag(parser):
     parser.set_defaults(verbose=True)
 
 
-def add_scale_flag(parser):
+def add_scale_flag(parser, required=True):
     parser.add_argument(
         "--scale",
         "-s",
         help="Scale of the dataset (e.g. 11.2,11.2,25). This is the size of one voxel in nm.",
-        required=True,
+        required=required,
     )
 
 


### PR DESCRIPTION
- automatically refreshes metadata after using the downsampling CLI command (@valentin-pinkau)
- fixes #123 by making the scale only optional when creating the metadata for the first time