### PR TITLE
Pad knossos

### DIFF
--- a/wkcuber/knossos.py
+++ b/wkcuber/knossos.py
@@ -36,9 +36,10 @@ class KnossosDataset:
         if filename is None:
             return np.zeros((CUBE_EDGE_LEN,) * 3, dtype=self.dtype)
         with open(filename, "rb") as cube_file:
-            cube_data = np.fromfile(cube_file, dtype=self.dtype).reshape(
-                (CUBE_EDGE_LEN,) * 3, order="F"
-            )
+            file_data = np.fromfile(cube_file, dtype=self.dtype)
+            cube_data = np.zeros(CUBE_EDGE_LEN * 3, dtype=self.dtype)
+            cube_data[0 : file_data.size] = file_data
+            cube_data = cube_data.reshape((CUBE_EDGE_LEN,) * 3, order="F")
             return cube_data
 
     def write_cube(self, cube_xyz, cube_data):

--- a/wkcuber/knossos.py
+++ b/wkcuber/knossos.py
@@ -37,7 +37,7 @@ class KnossosDataset:
             return np.zeros((CUBE_EDGE_LEN,) * 3, dtype=self.dtype)
         with open(filename, "rb") as cube_file:
             file_data = np.fromfile(cube_file, dtype=self.dtype)
-            cube_data = np.zeros(CUBE_EDGE_LEN * 3, dtype=self.dtype)
+            cube_data = np.zeros(CUBE_EDGE_LEN ** 3, dtype=self.dtype)
             cube_data[0 : file_data.size] = file_data
             cube_data = cube_data.reshape((CUBE_EDGE_LEN,) * 3, order="F")
             return cube_data

--- a/wkcuber/knossos.py
+++ b/wkcuber/knossos.py
@@ -5,6 +5,8 @@ from os import path
 from glob import iglob, glob
 
 CUBE_EDGE_LEN = 128
+CUBE_SIZE = CUBE_EDGE_LEN ** 3
+CUBE_SHAPE = (CUBE_EDGE_LEN,) * 3
 CUBE_REGEX = re.compile(r"x(\d+)/y(\d+)/z(\d+)/(.*\.raw)$")
 
 
@@ -17,29 +19,27 @@ class KnossosDataset:
         assert offset[0] % CUBE_EDGE_LEN == 0
         assert offset[1] % CUBE_EDGE_LEN == 0
         assert offset[2] % CUBE_EDGE_LEN == 0
-        assert shape[0] == CUBE_EDGE_LEN
-        assert shape[1] == CUBE_EDGE_LEN
-        assert shape[2] == CUBE_EDGE_LEN
+        assert shape == CUBE_SHAPE
         return self.read_cube(tuple(x // CUBE_EDGE_LEN for x in offset))
 
     def write(self, offset, data):
         assert offset[0] % CUBE_EDGE_LEN == 0
         assert offset[1] % CUBE_EDGE_LEN == 0
         assert offset[2] % CUBE_EDGE_LEN == 0
-        assert data.shape[0] == CUBE_EDGE_LEN
-        assert data.shape[1] == CUBE_EDGE_LEN
-        assert data.shape[2] == CUBE_EDGE_LEN
+        assert data.shape == CUBE_SHAPE
         self.write_cube(tuple(x // CUBE_EDGE_LEN for x in offset), data)
 
     def read_cube(self, cube_xyz):
         filename = self.__get_only_raw_file_path(cube_xyz)
         if filename is None:
-            return np.zeros((CUBE_EDGE_LEN,) * 3, dtype=self.dtype)
+            return np.zeros(CUBE_SHAPE, dtype=self.dtype)
         with open(filename, "rb") as cube_file:
-            file_data = np.fromfile(cube_file, dtype=self.dtype)
-            cube_data = np.zeros(CUBE_EDGE_LEN ** 3, dtype=self.dtype)
-            cube_data[0 : file_data.size] = file_data
-            cube_data = cube_data.reshape((CUBE_EDGE_LEN,) * 3, order="F")
+            cube_data = np.fromfile(cube_file, dtype=self.dtype)
+            if cube_data.size != CUBE_SIZE:
+                padded_data = np.zeros(CUBE_SIZE, dtype=self.dtype)
+                padded_data[0 : min(file_data.size, CUBE_SIZE)] = cube_data
+                cube_data = padded_data
+            cube_data = cube_data.reshape(CUBE_SHAPE, order="F")
             return cube_data
 
     def write_cube(self, cube_xyz, cube_data):


### PR DESCRIPTION
Some knossos `*.raw` files are truncated if the rest of the data are zeros. This PR pads these half-full blocks and truncates over-full blocks.