### PR TITLE
Fix scale passing in main for downsample_mags_anisotropic

### DIFF
--- a/wkcuber/__main__.py
+++ b/wkcuber/__main__.py
@@ -65,7 +65,7 @@ def main(args):
             args.layer_name,
             Mag(1),
             Mag(args.max_mag),
-            scale,
+            args.scale,
             "default",
             not args.no_compress,
             args=args,


### PR DESCRIPTION
Before #139 the scale was extracted to a separate variable, but now it was just missing. So we need to use args.scale.