### PR TITLE
Fix edge case in get_next_anisotropic_mag

### DIFF
--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -207,14 +207,15 @@ def test_anisotropic_mag_calculation():
         [(10.5, 24, 10.5), Mag((2, 1, 2)), Mag((4, 1, 4))],
         [(24, 10.5, 10.5), Mag((1, 2, 2)), Mag((1, 4, 4))],
         [(10.5, 10.5, 10.5), Mag(2), Mag(4)],
+        [(320, 320, 200), Mag(1), Mag((1, 1, 2))],
+        [(320, 320, 200), Mag((1, 1, 2)), Mag((2, 2, 4))],
     ]
+
     for i in range(len(mag_tests)):
-        assert mag_tests[i][2] == get_next_anisotropic_mag(
-            mag_tests[i][1], mag_tests[i][0]
-        ), (
+        next_mag = get_next_anisotropic_mag(mag_tests[i][1], mag_tests[i][0])
+        assert mag_tests[i][2] == next_mag, (
             "The next anisotropic"
-            " Magnification of {} with "
-            "the size {} should be {}".format(
-                mag_tests[i][1], mag_tests[i][0], mag_tests[i][2]
-            )
+            f" Magnification of {mag_tests[i][1]} with "
+            f"the size {mag_tests[i][0]} should be {mag_tests[i][2]} "
+            f"and not {next_mag}"
         )

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -632,12 +632,13 @@ def get_next_anisotropic_mag(mag, scale):
     max_index, min_index = detect_larger_and_smaller_dimension(scale)
     mag_array = mag.to_array()
     scale_increase = [1, 1, 1]
+
     if (
         mag_array[min_index] * scale[min_index]
         < mag_array[max_index] * scale[max_index]
     ):
         for i in range(len(scale_increase)):
-            scale_increase[i] = 1 if i == max_index else 2
+            scale_increase[i] = 1 if scale[i] == scale[max_index] else 2
     else:
         scale_increase = [2, 2, 2]
     return Mag(


### PR DESCRIPTION
The old code indirectly assumed that there is only one maximum element in the scale (e.g., `24, 24, 70`). However, there are datasets which have multiple maximum elements (e.g., `320, 320, 200`).
This PR fixes the these cases.

Fixes #176