### PR TITLE
Enable Compression for NIFTI Conversion Script

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/Caskroom/miniconda/base/bin/python"
+}

--- a/wkcuber/convert_nifti.py
+++ b/wkcuber/convert_nifti.py
@@ -73,7 +73,12 @@ def to_target_datatype(data: np.ndarray, target_dtype) -> np.ndarray:
 
 def convert_nifti(source_nifti_path, target_path, layer_name, dtype, scale, mag=1):
     target_wkw_info = WkwDatasetInfo(
-        str(target_path.resolve()), layer_name, mag, wkw.Header(np.dtype(dtype), block_type=wkw.Header.BLOCK_TYPE_LZ4HC, file_len=256)
+        str(target_path.resolve()),
+        layer_name,
+        mag,
+        wkw.Header(
+            np.dtype(dtype), block_type=wkw.Header.BLOCK_TYPE_LZ4HC, file_len=256
+        ),
     )
     ensure_wkw(target_wkw_info)
 

--- a/wkcuber/convert_nifti.py
+++ b/wkcuber/convert_nifti.py
@@ -71,13 +71,17 @@ def to_target_datatype(data: np.ndarray, target_dtype) -> np.ndarray:
     return (data / factor).astype(np.dtype(target_dtype))
 
 
-def convert_nifti(source_nifti_path, target_path, layer_name, dtype, scale, mag=1):
+def convert_nifti(
+    source_nifti_path, target_path, layer_name, dtype, scale, mag=1, file_len=256
+):
     target_wkw_info = WkwDatasetInfo(
         str(target_path.resolve()),
         layer_name,
         mag,
         wkw.Header(
-            np.dtype(dtype), block_type=wkw.Header.BLOCK_TYPE_LZ4HC, file_len=256
+            np.dtype(dtype),
+            block_type=wkw.Header.BLOCK_TYPE_LZ4HC,
+            file_len=file_len // 32,
         ),
     )
     ensure_wkw(target_wkw_info)
@@ -111,6 +115,20 @@ def convert_nifti(source_nifti_path, target_path, layer_name, dtype, scale, mag=
             scale = tuple(map(float, source_nifti.header["pixdim"][:3]))
 
         cube_data = to_target_datatype(cube_data, dtype)
+
+        # Writing wkw compressed requires files of shape (file_len, file_len, file_len)
+        # Pad data accordingly
+        padding_offset = file_len - np.array(cube_data.shape[1:4]) % file_len
+        cube_data = np.pad(
+            cube_data,
+            (
+                (0, 0),
+                (0, int(padding_offset[0])),
+                (0, int(padding_offset[1])),
+                (0, int(padding_offset[2])),
+            ),
+        )
+
         target_wkw.write(offset, cube_data)
 
     logging.debug(

--- a/wkcuber/convert_nifti.py
+++ b/wkcuber/convert_nifti.py
@@ -73,7 +73,7 @@ def to_target_datatype(data: np.ndarray, target_dtype) -> np.ndarray:
 
 def convert_nifti(source_nifti_path, target_path, layer_name, dtype, scale, mag=1):
     target_wkw_info = WkwDatasetInfo(
-        str(target_path.resolve()), layer_name, mag, wkw.Header(np.dtype(dtype))
+        str(target_path.resolve()), layer_name, mag, wkw.Header(np.dtype(dtype), block_type=wkw.Header.BLOCK_TYPE_LZ4HC, file_len=256)
     )
     ensure_wkw(target_wkw_info)
 


### PR DESCRIPTION
PR changes: 
- Enables wkw Compression for NIFTI Conversion Script
- Reduce wkw file length to 256 (instead of 1024) to account for smaller MRI datasets