### PR TITLE
Miscellaneous API fixes

### DIFF
--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -60,7 +60,12 @@ class AbstractDataset(ABC):
             )
         return self.layers[layer_name]
 
-    def add_layer(self, layer_name, category, dtype=np.dtype("uint8"), num_channels=1):
+    def add_layer(self, layer_name, category, dtype=None, num_channels=None):
+        if dtype is None:
+            dtype = np.dtype("uint8")
+        if num_channels is None:
+            num_channels = 1
+
         # normalize the value of dtype in case the parameter was passed as a string
         dtype = np.dtype(dtype)
 

--- a/wkcuber/api/Layer.py
+++ b/wkcuber/api/Layer.py
@@ -58,7 +58,14 @@ class Layer:
 
 
 class WKLayer(Layer):
-    def add_mag(self, mag, block_len=32, file_len=32, block_type=1) -> WKMagDataset:
+    def add_mag(self, mag, block_len=None, file_len=None, block_type=None) -> WKMagDataset:
+        if block_len is None:
+            block_len = 32
+        if file_len is None:
+            file_len = 32
+        if block_type is None:
+            block_type = wkw.Header.BLOCK_TYPE_RAW
+
         # normalize the name of the mag
         mag = Mag(mag).to_layer_name()
 

--- a/wkcuber/api/Layer.py
+++ b/wkcuber/api/Layer.py
@@ -58,7 +58,9 @@ class Layer:
 
 
 class WKLayer(Layer):
-    def add_mag(self, mag, block_len=None, file_len=None, block_type=None) -> WKMagDataset:
+    def add_mag(
+        self, mag, block_len=None, file_len=None, block_type=None
+    ) -> WKMagDataset:
         if block_len is None:
             block_len = 32
         if file_len is None:

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -37,7 +37,12 @@ class MagDataset:
             if current_offset == (-1, -1, -1)
             else tuple(min(x) for x in zip(current_offset, offset))
         )
-        total_size = tuple(max(x) for x in zip(current_size, data.shape[-3:]))
+
+        old_end_offset = np.array(current_offset) + np.array(current_size)
+        new_end_offset = np.array(offset) + np.array(data.shape[-3:])
+        max_end_offset = np.array([old_end_offset, new_end_offset]).max(axis=0)
+        total_size = tuple(max_end_offset - np.array(new_offset))
+
         self.view.size = total_size
 
         self.layer.dataset.properties._set_bounding_box_of_layer(

--- a/wkcuber/api/Properties/LayerProperties.py
+++ b/wkcuber/api/Properties/LayerProperties.py
@@ -194,7 +194,7 @@ class SegmentationLayerProperties(LayerProperties):
             json_data["boundingBox"],
             None,
             json_data["largestSegmentId"],
-            json_data["mappings"],
+            json_data["mappings"] if "mappings" in json_data else None,
         )
 
         # add resolutions to LayerProperties

--- a/wkcuber/api/Properties/LayerProperties.py
+++ b/wkcuber/api/Properties/LayerProperties.py
@@ -109,12 +109,14 @@ class LayerProperties:
         return tuple(self.bounding_box["topLeft"])
 
     def _set_bounding_box_size(self, size):
-        self._bounding_box["width"] = size[0]
-        self._bounding_box["height"] = size[1]
-        self._bounding_box["depth"] = size[2]
+        # Cast to int in case the provided parameter contains numpy integer
+        self._bounding_box["width"] = int(size[0])
+        self._bounding_box["height"] = int(size[1])
+        self._bounding_box["depth"] = int(size[2])
 
     def _set_bounding_box_offset(self, offset):
-        self._bounding_box["topLeft"] = offset
+        # Cast to int in case the provided parameter contains numpy integer
+        self._bounding_box["topLeft"] = tuple(map(int, offset))
 
     @property
     def name(self) -> str:

--- a/wkcuber/api/TiffData/TiffMag.py
+++ b/wkcuber/api/TiffData/TiffMag.py
@@ -38,7 +38,11 @@ def detect_tile_ranges(
         if full_pattern.startswith(os.path.sep):
             prefix = "/"
 
-        detected_z_range, detected_x_range, detected_y_range = detect_tile_ranges_from_pattern_recursively(
+        (
+            detected_z_range,
+            detected_x_range,
+            detected_y_range,
+        ) = detect_tile_ranges_from_pattern_recursively(
             pattern_split, prefix, set(), set(), set()
         )
 
@@ -57,9 +61,11 @@ def detect_tile_ranges_from_pattern_recursively(
     x_values: Set[int],
     y_values: Set[int],
 ) -> Tuple[Optional[range], Optional[range], Optional[range]]:
-    current_pattern_element, prefix, remaining_pattern_elements = advance_to_next_relevant_pattern_element(
-        pattern_elements, prefix
-    )
+    (
+        current_pattern_element,
+        prefix,
+        remaining_pattern_elements,
+    ) = advance_to_next_relevant_pattern_element(pattern_elements, prefix)
     items = os.listdir(prefix)
     for ls_item in items:
         _, file_extension = os.path.splitext(pattern_elements[-1])


### PR DESCRIPTION
- new bbox shape wasn't enlarged automatically in some cases
- default `None` values of `get_or_add` were passed as such to `add` methods, which then wouldn't use its own defaults
- parsing datasource properties failed if `mappings` parameter is not included (which can be produced by the cuber api itself)

@rschwanhold Please have a look and check whether my changes make sense :)