### PR TITLE
fix channel checking for dataset-write

### DIFF
--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -105,7 +105,7 @@ class MagDataset:
             ), f"The number of channels of the dataset ({num_channels}) does not match the number of channels of the passed data (1)"
         else:
             assert (
-                num_channels == 3
+                num_channels == write_data_shape[0]
             ), f"The number of channels of the dataset ({num_channels}) does not match the number of channels of the passed data ({write_data_shape[0]})"
 
 


### PR DESCRIPTION
When trying to write chunks via the API I got the following error message:
```
AssertionError: The number of channels of the dataset (1)
does not match the number of channels of the passed data (1)
```
I think this fixes the underlying bug, it now checks what the error message says and makes sense to me.