### PR TITLE
Assert that bounding box and mag are aligned

### DIFF
--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -1,6 +1,4 @@
-import numpy as np
 from wkcuber.api.bounding_box import BoundingBox, Mag
-from wkcuber.metadata import detect_resolutions
 import pytest
 
 

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -4,10 +4,18 @@ import pytest
 
 def test_align_with_mag():
 
-    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2)) == BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
-    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(topleft=(0, 0, 0), size=(10, 10, 10))
-    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4)) == BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
-    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(topleft=(0, 2, 2), size=(10, 10, 10))
+    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2)) == BoundingBox(
+        topleft=(0, 0, 0), size=(12, 12, 12)
+    )
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(
+        topleft=(0, 0, 0), size=(10, 10, 10)
+    )
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4)) == BoundingBox(
+        topleft=(0, 0, 0), size=(12, 12, 12)
+    )
+    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(
+        topleft=(0, 2, 2), size=(10, 10, 10)
+    )
 
 
 def test_in_mag():
@@ -18,4 +26,6 @@ def test_in_mag():
     with pytest.raises(AssertionError):
         BoundingBox((2, 2, 2), (9, 9, 9)).in_mag(Mag(2))
 
-    assert BoundingBox((2, 2, 2), (10, 10, 10)).in_mag(Mag(2)) == BoundingBox(topleft=(1, 1, 1), size=(5, 5, 5))
+    assert BoundingBox((2, 2, 2), (10, 10, 10)).in_mag(Mag(2)) == BoundingBox(
+        topleft=(1, 1, 1), size=(5, 5, 5)
+    )

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -1,0 +1,23 @@
+import numpy as np
+from wkcuber.api.bounding_box import BoundingBox, Mag
+from wkcuber.metadata import detect_resolutions
+import pytest
+
+
+def test_align_with_mag():
+
+    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2)) == BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(topleft=(0, 0, 0), size=(10, 10, 10))
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4)) == BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
+    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(topleft=(0, 2, 2), size=(10, 10, 10))
+
+
+def test_in_mag():
+
+    with pytest.raises(AssertionError):
+        BoundingBox((1, 2, 3), (9, 9, 9)).in_mag(Mag(2))
+
+    with pytest.raises(AssertionError):
+        BoundingBox((2, 2, 2), (9, 9, 9)).in_mag(Mag(2))
+
+    assert BoundingBox((2, 2, 2), (10, 10, 10)).in_mag(Mag(2)) == BoundingBox(topleft=(1, 1, 1), size=(5, 5, 5))


### PR DESCRIPTION
Towards fixing https://github.com/scalableminds/voxelytics/issues/1650, I added the following to our `BoundingBox` class:
- `BoundingBox.in_mag()` does not to any implicit rounding (hence does not have a `ceil` attribute anymore). Instead, it fails hard if the bounding box cannot unambiguously be converted to a given mag.
- `BoundingBox.align_with_mag()` implements what you'll typically want to do in that case: round the bounding box up (i.e., make it larger) until it is mag aligned.

These are a few test cases:
```
>>> BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2))
BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
>>> BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2))
BoundingBox(topleft=(0, 0, 0), size=(10, 10, 10))
>>> BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4))
BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
>>> BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2))
BoundingBox(topleft=(0, 2, 2), size=(10, 10, 10))
>>> BoundingBox((1, 2, 3), (9, 9, 9)).in_mag(Mag(2))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/georg/coding/webknossos-cuber/wkcuber/api/bounding_box.py", line 194, in in_mag
    ), f"topleft {self.topleft} is not aligned with the mag {mag}. Use BoundingBox.align_with_mag()."
AssertionError: topleft [1 2 3] is not aligned with the mag 2. Use BoundingBox.align_with_mag().
>>> BoundingBox((2, 2, 2), (9, 9, 9)).in_mag(Mag(2))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/georg/coding/webknossos-cuber/wkcuber/api/bounding_box.py", line 197, in in_mag
    ), f"bottomright {self.bottomright} is not aligned with the mag {mag}. Use BoundingBox.align_with_mag()."
AssertionError: bottomright [11 11 11] is not aligned with the mag 2. Use BoundingBox.align_with_mag().
>>> BoundingBox((2, 2, 2), (10, 10, 10)).in_mag(Mag(2))
BoundingBox(topleft=(1, 1, 1), size=(5, 5, 5))
```