### PR TITLE
Floored version of align_with_mag()

### DIFF
--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -2,19 +2,35 @@ from wkcuber.api.bounding_box import BoundingBox, Mag
 import pytest
 
 
-def test_align_with_mag():
+def test_align_with_mag_ceiled():
 
-    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2)) == BoundingBox(
+    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2), ceil=True) == BoundingBox(
         topleft=(0, 0, 0), size=(12, 12, 12)
     )
-    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2), ceil=True) == BoundingBox(
         topleft=(0, 0, 0), size=(10, 10, 10)
     )
-    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4)) == BoundingBox(
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4), ceil=True) == BoundingBox(
         topleft=(0, 0, 0), size=(12, 12, 12)
     )
-    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(
+    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2), ceil=True) == BoundingBox(
         topleft=(0, 2, 2), size=(10, 10, 10)
+    )
+
+
+def test_align_with_mag_floored():
+
+    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2)) == BoundingBox(
+        topleft=(2, 2, 2), size=(8, 8, 8)
+    )
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(
+        topleft=(2, 2, 2), size=(8, 8, 8)
+    )
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4)) == BoundingBox(
+        topleft=(4, 4, 4), size=(4, 4, 4)
+    )
+    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2)) == BoundingBox(
+        topleft=(2, 2, 4), size=(8, 8, 8)
     )
 
 

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -4,18 +4,18 @@ import pytest
 
 def test_align_with_mag_ceiled():
 
-    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(Mag(2), ceil=True) == BoundingBox(
-        topleft=(0, 0, 0), size=(12, 12, 12)
-    )
-    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(2), ceil=True) == BoundingBox(
-        topleft=(0, 0, 0), size=(10, 10, 10)
-    )
-    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(Mag(4), ceil=True) == BoundingBox(
-        topleft=(0, 0, 0), size=(12, 12, 12)
-    )
-    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(Mag(2), ceil=True) == BoundingBox(
-        topleft=(0, 2, 2), size=(10, 10, 10)
-    )
+    assert BoundingBox((1, 1, 1), (10, 10, 10)).align_with_mag(
+        Mag(2), ceil=True
+    ) == BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(
+        Mag(2), ceil=True
+    ) == BoundingBox(topleft=(0, 0, 0), size=(10, 10, 10))
+    assert BoundingBox((1, 1, 1), (9, 9, 9)).align_with_mag(
+        Mag(4), ceil=True
+    ) == BoundingBox(topleft=(0, 0, 0), size=(12, 12, 12))
+    assert BoundingBox((1, 2, 3), (9, 9, 9)).align_with_mag(
+        Mag(2), ceil=True
+    ) == BoundingBox(topleft=(0, 2, 2), size=(10, 10, 10))
 
 
 def test_align_with_mag_floored():

--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -209,7 +209,8 @@ class BoundingBox:
 
         np_mag = np.array(mag.to_array())
 
-        align = lambda point, round_fn: return round_fn(point / np_mag).astype(np.int) * np_mag
+        align = lambda point, round_fn: round_fn(point / np_mag).astype(np.int) * np_mag
+
         if ceil:
             topleft = align(self.topleft, np.floor)
             bottomright = align(self.bottomright, np.ceil)

--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -204,7 +204,7 @@ class BoundingBox:
     def align_with_mag(self, mag: Mag, ceil=False):
         """Rounds the bounding box, so that both topleft and bottomright are divisible by mag.
 
-        :argument ceil: If true, we read more, otherwise less.
+        :argument ceil: If true, the bounding box is enlarged when necessary. If false, it's shrinked when necessary.
         """
 
         np_mag = np.array(mag.to_array())

--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -201,12 +201,21 @@ class BoundingBox:
             size=(self.size // np_mag).astype(np.int),
         )
 
-    def align_with_mag(self, mag: Mag):
-        """Rounds the bounding box up, so that both topleft and bottomright are divisible by mag."""
+    def align_with_mag(self, mag: Mag, ceil=False):
+        """Rounds the bounding box, so that both topleft and bottomright are divisible by mag.
+
+        :argument ceil: If true, we read more, otherwise less.
+        """
 
         np_mag = np.array(mag.to_array())
-        topleft = (self.topleft // np_mag).astype(np.int) * np_mag
-        bottomright = np.ceil(self.bottomright / np_mag).astype(np.int) * np_mag
+
+        if ceil:
+            topleft = np.floor(self.topleft / np_mag).astype(np.int) * np_mag
+            bottomright = np.ceil(self.bottomright / np_mag).astype(np.int) * np_mag
+        else:
+            topleft = np.ceil(self.topleft / np_mag).astype(np.int) * np_mag
+            bottomright = np.floor(self.bottomright / np_mag).astype(np.int) * np_mag
+
         return BoundingBox(topleft, bottomright - topleft)
 
     def contains(self, coord: Shape3D) -> bool:

--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -209,13 +209,13 @@ class BoundingBox:
 
         np_mag = np.array(mag.to_array())
 
+        align = lambda point, round_fn: return round_fn(point / np_mag).astype(np.int) * np_mag
         if ceil:
-            topleft = np.floor(self.topleft / np_mag).astype(np.int) * np_mag
-            bottomright = np.ceil(self.bottomright / np_mag).astype(np.int) * np_mag
+            topleft = align(self.topleft, np.floor)
+            bottomright = align(self.bottomright, np.ceil)
         else:
-            topleft = np.ceil(self.topleft / np_mag).astype(np.int) * np_mag
-            bottomright = np.floor(self.bottomright / np_mag).astype(np.int) * np_mag
-
+            topleft = align(self.topleft, np.ceil)
+            bottomright = align(self.bottomright, np.floor)
         return BoundingBox(topleft, bottomright - topleft)
 
     def contains(self, coord: Shape3D) -> bool:


### PR DESCRIPTION
Follow-up to #211 

When bounding boxes are not aligned, we will also sometimes want a floored version of `align_with_mag()`. For example, when we read annotated training data, we want to make sure we never read voxels that are not annotated.