### PR TITLE
Add __expr__ for mag class

### DIFF
--- a/wkcuber/mag.py
+++ b/wkcuber/mag.py
@@ -48,6 +48,9 @@ class Mag:
     def __str__(self):
         return self.to_layer_name()
 
+    def __expr__(self):
+        return f"Mag({self.to_layer_name()})"
+
     def to_layer_name(self):
         x, y, z = self.mag
         if x == y and y == z:


### PR DESCRIPTION
When Mags are printed/logged without explicit str casting, the default formatting is not very helpful as it only uses python's instance formatting. Consequently, printing a list of mags etc. is quite cumbersome, since one needs to convert the list to a list of strings first. Implementing the `__expr__` method improves this situation vastly.