### PR TITLE
Dataset API changes: parameter 'dtype' is now interpreted as 'dtype_per_layer' and parameter list for 'read(...)' was reordered to match wkw.Dataset.read(...)

### DIFF
--- a/testdata/simple_wk_dataset/datasource-properties.json
+++ b/testdata/simple_wk_dataset/datasource-properties.json
@@ -11,7 +11,7 @@
             "dataFormat": "wkw",
             "name": "color",
             "category": "color",
-            "elementClass": "uint8",
+            "elementClass": "uint24",
             "num_channels": 3,
             "boundingBox": {
                 "topLeft": [

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1279,9 +1279,22 @@ def test_view_offsets():
 
 
 def test_adding_layer_with_invalid_dtype_per_layer():
-    delete_dir("./testoutput/wk_dataset_write_without_open")
+    delete_dir("./testoutput/invalid_dtype")
 
-    ds = WKDataset.create("./testoutput/wk_dataset_write_without_open", scale=(1, 1, 1))
+    ds = WKDataset.create("./testoutput/invalid_dtype", scale=(1, 1, 1))
     with pytest.raises(TypeError):
         # this would lead to a dtype_per_channel of "uint10", but that is not a valid dtype
         ds.add_layer("color", "color", dtype_per_layer="uint30", num_channels=3)
+    with pytest.raises(TypeError):
+        # the dtype_per_layer must contain a digit (e.g. np.uint8)
+        ds.add_layer("color", "color", dtype_per_layer="int", num_channels=3)
+
+
+def test_adding_layer_with_valid_dtype_per_layer():
+    delete_dir("./testoutput/valid_dtype")
+
+    ds = WKDataset.create("./testoutput/valid_dtype", scale=(1, 1, 1))
+    ds.add_layer("color1", Layer.COLOR_TYPE, dtype_per_layer="uint24", num_channels=3)
+    ds.add_layer("color2", Layer.COLOR_TYPE, dtype_per_layer=np.uint8, num_channels=1)
+    ds.add_layer("color3", Layer.COLOR_TYPE, dtype_per_channel=np.uint8, num_channels=3)
+    ds.add_layer("color4", Layer.COLOR_TYPE, dtype_per_channel="uint8", num_channels=3)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1289,7 +1289,9 @@ def test_adding_layer_with_invalid_dtype_per_layer():
     with pytest.raises(TypeError):
         # "int" is interpreted as "int64", but 64 bit cannot be split into 3 channels
         ds.add_layer("color", "color", dtype_per_layer="int", num_channels=3)
-    ds.add_layer("color", "color", dtype_per_layer="int", num_channels=4)  # "int"/"int64" works with 4 channels
+    ds.add_layer(
+        "color", "color", dtype_per_layer="int", num_channels=4
+    )  # "int"/"int64" works with 4 channels
 
 
 def test_adding_layer_with_valid_dtype_per_layer():

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -29,14 +29,19 @@ def dtype_per_layer_to_dtype_per_channel(dtype_per_layer, num_channels):
         return None
     # split the dtype into the actual type and the number of bits
     # example: "uint24" -> ["uint", "24"]
-    dtype_per_layer_parts = re.split('(\d+)', str(dtype_per_layer))
+    dtype_per_layer_parts = re.split("(\d+)", str(dtype_per_layer))
     # calculate number of bits for dtype_per_channel
-    dtype_per_channel_parts = [(str(int(int(part) / num_channels)) if is_int(part) else part) for part in
-                               dtype_per_layer_parts]
+    dtype_per_channel_parts = [
+        (str(int(int(part) / num_channels)) if is_int(part) else part)
+        for part in dtype_per_layer_parts
+    ]
     try:
-        return np.dtype(''.join(dtype_per_channel_parts))
+        return np.dtype("".join(dtype_per_channel_parts))
     except TypeError as e:
-        raise TypeError("Converting dtype_per_layer to dtype_per_channel failed. Double check if the dtype_per_layer value is correct. " + str(e))
+        raise TypeError(
+            "Converting dtype_per_layer to dtype_per_channel failed. Double check if the dtype_per_layer value is correct. "
+            + str(e)
+        )
 
 
 class AbstractDataset(ABC):
@@ -96,11 +101,13 @@ class AbstractDataset(ABC):
             )
         return self.layers[layer_name]
 
-    def add_layer(self, layer_name, category, dtype_per_layer=None, num_channels=None, **kwargs):
+    def add_layer(
+        self, layer_name, category, dtype_per_layer=None, num_channels=None, **kwargs
+    ):
         if num_channels is None:
             num_channels = 1
         if dtype_per_layer is None:
-            dtype_per_layer = "uint" + str(8*num_channels)
+            dtype_per_layer = "uint" + str(8 * num_channels)
 
         if layer_name in self.layers.keys():
             raise IndexError(
@@ -110,12 +117,21 @@ class AbstractDataset(ABC):
             )
 
         # check if dtype_per_channel is a valid dtype
-        dtype_per_channel = dtype_per_layer_to_dtype_per_channel(dtype_per_layer, num_channels)
+        dtype_per_channel = dtype_per_layer_to_dtype_per_channel(
+            dtype_per_layer, num_channels
+        )
 
         self.properties._add_layer(
-            layer_name, category, dtype_per_layer, self.data_format, num_channels, **kwargs
+            layer_name,
+            category,
+            dtype_per_layer,
+            self.data_format,
+            num_channels,
+            **kwargs,
         )
-        self.layers[layer_name] = self._create_layer(layer_name, dtype_per_channel, num_channels)
+        self.layers[layer_name] = self._create_layer(
+            layer_name, dtype_per_channel, num_channels
+        )
         return self.layers[layer_name]
 
     def get_or_add_layer(
@@ -127,8 +143,13 @@ class AbstractDataset(ABC):
                 + f"The category of the existing layer is '{self.properties.data_layers[layer_name].category}' "
                 + f"and the passed parameter is '{category}'."
             )
-            dtype_per_channel = dtype_per_layer_to_dtype_per_channel(dtype_per_layer, num_channels)
-            assert dtype_per_layer is None or self.layers[layer_name].dtype_per_channel == dtype_per_channel, (
+            dtype_per_channel = dtype_per_layer_to_dtype_per_channel(
+                dtype_per_layer, num_channels
+            )
+            assert (
+                dtype_per_layer is None
+                or self.layers[layer_name].dtype_per_channel == dtype_per_channel
+            ), (
                 f"Cannot get_or_add_layer: The layer '{layer_name}' already exists, but the dtypes do not match. "
                 + f"The dtype_per_channel of the existing layer is '{self.layers[layer_name].dtype_per_channel}' "
                 + f"and the passed parameter would result in a dtype_per_channel of '{dtype_per_channel}'."
@@ -143,7 +164,9 @@ class AbstractDataset(ABC):
             )
             return self.layers[layer_name]
         else:
-            return self.add_layer(layer_name, category, dtype_per_layer, num_channels, **kwargs)
+            return self.add_layer(
+                layer_name, category, dtype_per_layer, num_channels, **kwargs
+            )
 
     def delete_layer(self, layer_name):
         if layer_name not in self.layers.keys():

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -32,11 +32,6 @@ def convert_dtypes(dtype, num_channels, dtype_per_layer_to_dtype_per_channel):
         return None
     op = operator.truediv if dtype_per_layer_to_dtype_per_channel else operator.mul
 
-    if not any(char.isdigit() for char in str(dtype)):
-        raise TypeError(
-            f"Converting dtype_per_layer to dtype_per_channel failed. The dtype {str(dtype)} must contain a digit."
-        )
-
     # split the dtype into the actual type and the number of bits
     # example: "uint24" -> ["uint", "24"]
     dtype_parts = re.split("(\d+)", str(dtype))
@@ -158,8 +153,10 @@ class AbstractDataset(ABC):
                 dtype_per_channel, num_channels
             )
         elif dtype_per_layer is not None:
-            if type(dtype_per_layer) is not str:
+            try:
                 dtype_per_layer = str(np.dtype(dtype_per_layer))
+            except Exception:
+                pass  # casting to np.dtype fails if the user specifies a special dtype like "uint24"
             dtype_per_channel = dtype_per_layer_to_dtype_per_channel(
                 dtype_per_layer, num_channels
             )

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -258,7 +258,9 @@ class AbstractDataset(ABC):
 
         self.layers[layer_name] = self._create_layer(
             layer_name,
-            np.dtype(layer_properties.element_class),
+            dtype_per_layer_to_dtype_per_channel(
+                layer_properties.element_class, layer_properties.num_channels
+            ),
             layer_properties.num_channels,
         )
         for resolution in layer_properties.wkw_magnifications:

--- a/wkcuber/api/Layer.py
+++ b/wkcuber/api/Layer.py
@@ -22,10 +22,10 @@ class Layer:
     COLOR_TYPE = "color"
     SEGMENTATION_TYPE = "segmentation"
 
-    def __init__(self, name, dataset, dtype, num_channels):
+    def __init__(self, name, dataset, dtype_per_channel, num_channels):
         self.name = name
         self.dataset = dataset
-        self.dtype = dtype
+        self.dtype_per_channel = dtype_per_channel
         self.num_channels = num_channels
         self.mags = {}
 

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -23,8 +23,8 @@ class MagDataset:
     def close(self):
         self.view.close()
 
-    def read(self, size, offset=(0, 0, 0)) -> np.array:
-        return self.view.read(size, offset)
+    def read(self, offset=(0, 0, 0), size=None) -> np.array:
+        return self.view.read(offset, size)
 
     def write(self, data, offset=(0, 0, 0)):
         self._assert_valid_num_channels(data.shape)
@@ -178,4 +178,4 @@ class TiledTiffMagDataset(TiffMagDataset):
         offset = np.array((0, 0, 0)) + np.array(size) * np.array(
             (x_index, y_index, z_index)
         )
-        return self.read(size, offset)
+        return self.read(offset, size)

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -128,7 +128,7 @@ class WKMagDataset(MagDataset):
 
     def get_header(self) -> wkw.Header:
         return wkw.Header(
-            voxel_type=self.layer.dtype,
+            voxel_type=self.layer.dtype_per_channel,
             num_channels=self.layer.num_channels,
             version=1,
             block_len=self.block_len,
@@ -157,7 +157,7 @@ class TiffMagDataset(MagDataset):
     def get_header(self) -> TiffMagHeader:
         return TiffMagHeader(
             pattern=self.pattern,
-            dtype=self.layer.dtype,
+            dtype_per_channel=self.layer.dtype_per_channel,
             num_channels=self.layer.num_channels,
             tile_size=self.layer.dataset.properties.tile_size,
         )

--- a/wkcuber/api/TiffData/TiffMag.py
+++ b/wkcuber/api/TiffData/TiffMag.py
@@ -186,7 +186,7 @@ class TiffMag:
         # modify the shape to also include the num_channels
         shape = tuple(shape) + tuple([self.header.num_channels])
 
-        data = np.zeros(shape=shape, dtype=self.header.dtype)
+        data = np.zeros(shape=shape, dtype=self.header.dtype_per_channel)
         for (
             xyz,
             _,
@@ -198,7 +198,7 @@ class TiffMag:
 
             if xyz in self.tiffs:
                 # load data and discard the padded data
-                loaded_data = np.array(self.tiffs[xyz].read(), self.header.dtype)[
+                loaded_data = np.array(self.tiffs[xyz].read(), self.header.dtype_per_channel)[
                     offset_in_output_data[0] : offset_in_output_data[0] + shape[0],
                     offset_in_output_data[1] : offset_in_output_data[1] + shape[1],
                 ]
@@ -250,7 +250,7 @@ class TiffMag:
 
                 # initialize an empty image with the right shape
                 self.tiffs[xyz] = TiffReader.init_tiff(
-                    np.zeros(output_data_shape, self.header.dtype),
+                    np.zeros(output_data_shape, self.header.dtype_per_channel),
                     self.get_file_name_for_layer(xyz),
                 )
 
@@ -363,9 +363,9 @@ class TiffMag:
                 raise AttributeError(
                     f"The shape of the provided data does not match the expected shape. (Expected {self.header.num_channels} channels)"
                 )
-        if not np.dtype(data.dtype) == self.header.dtype:
+        if not np.dtype(data.dtype) == self.header.dtype_per_channel:
             raise AttributeError(
-                f"The type of the provided data does not match the expected type. (Expected np.array of type {self.header.dtype.name})"
+                f"The type of the provided data does not match the expected type. (Expected np.array of type {self.header.dtype_per_channel.name})"
             )
 
     def get_file_name_for_layer(self, xyz) -> str:
@@ -389,12 +389,12 @@ class TiffMagHeader:
     def __init__(
         self,
         pattern="{zzzzz}.tif",
-        dtype=np.dtype("uint8"),
+        dtype_per_channel=np.dtype("uint8"),
         num_channels=1,
         tile_size=(32, 32),
     ):
         self.pattern = pattern
-        self.dtype = np.dtype(dtype)
+        self.dtype_per_channel = np.dtype(dtype_per_channel)
         self.num_channels = num_channels
         self.tile_size = tile_size
 

--- a/wkcuber/api/TiffData/TiffMag.py
+++ b/wkcuber/api/TiffData/TiffMag.py
@@ -198,7 +198,9 @@ class TiffMag:
 
             if xyz in self.tiffs:
                 # load data and discard the padded data
-                loaded_data = np.array(self.tiffs[xyz].read(), self.header.dtype_per_channel)[
+                loaded_data = np.array(
+                    self.tiffs[xyz].read(), self.header.dtype_per_channel
+                )[
                     offset_in_output_data[0] : offset_in_output_data[0] + shape[0],
                     offset_in_output_data[1] : offset_in_output_data[1] + shape[1],
                 ]

--- a/wkcuber/api/View.py
+++ b/wkcuber/api/View.py
@@ -55,7 +55,7 @@ class View:
         if not was_opened:
             self.close()
 
-    def read(self, size=None, offset=(0, 0, 0)) -> np.array:
+    def read(self, offset=(0, 0, 0), size=None) -> np.array:
         was_opened = self._is_opened
         size = self.size if size is None else size
 

--- a/wkcuber/check_equality.py
+++ b/wkcuber/check_equality.py
@@ -62,7 +62,7 @@ def assert_equality_for_chunk(
         mag_ds = layer.get_mag(mag)
         logging.info(f"Checking sub_box: {sub_box}")
 
-        data = mag_ds.read(sub_box.size, sub_box.topleft)
+        data = mag_ds.read(sub_box.topleft, sub_box.size)
         backup_data = backup_wkw.read(sub_box.topleft, sub_box.size)
         assert np.all(
             data == backup_data

--- a/wkcuber/convert_nifti.py
+++ b/wkcuber/convert_nifti.py
@@ -140,7 +140,6 @@ def convert_nifti(
     assume_segmentation_layer = (
         False
     )  # Since webKnossos does not support multiple segmention layers, this is hardcoded to False right now.
-
     max_cell_id_args = (
         {"largest_segment_id": int(np.max(cube_data) + 1)}
         if assume_segmentation_layer
@@ -202,7 +201,10 @@ def convert_nifti(
     if write_tiff:
         ds = TiffDataset.get_or_create(target_path, scale=scale or (1, 1, 1))
         layer = ds.get_or_add_layer(
-            layer_name, category_type, np.dtype(dtype), **max_cell_id_args
+            layer_name,
+            category_type,
+            dtype_per_layer=np.dtype(dtype),
+            **max_cell_id_args,
         )
         mag = layer.get_or_add_mag("1")
 
@@ -210,7 +212,10 @@ def convert_nifti(
     else:
         ds = WKDataset.get_or_create(target_path, scale=scale or (1, 1, 1))
         layer = ds.get_or_add_layer(
-            layer_name, category_type, np.dtype(dtype), **max_cell_id_args
+            layer_name,
+            category_type,
+            dtype_per_layer=np.dtype(dtype),
+            **max_cell_id_args,
         )
         mag = layer.get_or_add_mag("1", file_len=file_len)
         mag.write(cube_data)


### PR DESCRIPTION
- The Dataset API now interprets the dtype per layer (not per channel)
- Reorder parameter list for `MagDataset.read(...)` and `View.read(...)` to match the order of `wkw.Dataset.read(...)`
- fixes: #235 
- fixes: #229 