### PR TITLE
Dataset API: search for datasets also in the path with the long mag name

### DIFF
--- a/wkcuber/api/Layer.py
+++ b/wkcuber/api/Layer.py
@@ -12,6 +12,7 @@ from wkcuber.api.MagDataset import (
     WKMagDataset,
     TiffMagDataset,
     TiledTiffMagDataset,
+    find_mag_path_on_disk,
 )
 from wkcuber.mag import Mag
 from wkcuber.utils import DEFAULT_WKW_FILE_LEN
@@ -48,7 +49,7 @@ class Layer:
         del self.mags[mag]
         self.dataset.properties._delete_mag(self.name, mag)
         # delete files on disk
-        full_path = join(self.dataset.path, self.name, mag)
+        full_path = find_mag_path_on_disk(self.dataset.path, self.name, mag)
         rmtree(full_path)
 
     def _create_dir_for_mag(self, mag):
@@ -138,7 +139,9 @@ class WKLayer(Layer):
 
         self._assert_mag_does_not_exist_yet(mag)
 
-        with wkw.Dataset.open(join(self.dataset.path, self.name, mag)) as wkw_dataset:
+        with wkw.Dataset.open(
+            find_mag_path_on_disk(self.dataset.path, self.name, mag)
+        ) as wkw_dataset:
             wk_header = wkw_dataset.header
 
         self.mags[mag] = WKMagDataset(

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -1,3 +1,4 @@
+import os
 from os.path import join
 
 from wkw import wkw
@@ -7,6 +8,16 @@ import wkcuber.api as api
 from wkcuber.api.View import WKView, TiffView
 from wkcuber.api.TiffData.TiffMag import TiffMagHeader
 from wkcuber.mag import Mag
+
+
+def find_mag_path_on_disk(dataset_path: str, layer_name: str, mag_name: str):
+    mag = Mag(mag_name)
+    short_mag_file_path = join(dataset_path, layer_name, mag.to_layer_name())
+    long_mag_file_path = join(dataset_path, layer_name, mag.to_long_layer_name())
+    if os.path.exists(short_mag_file_path):
+        return short_mag_file_path
+    else:
+        return long_mag_file_path
 
 
 class MagDataset:
@@ -99,7 +110,9 @@ class MagDataset:
                         f"Use is_bounded=False if you intend to write outside out the existing bounding box."
                     )
 
-        mag_file_path = join(self.layer.dataset.path, self.layer.name, self.name)
+        mag_file_path = find_mag_path_on_disk(
+            self.layer.dataset.path, self.layer.name, self.name
+        )
         return self._get_view_type()(
             mag_file_path, self.header, size, offset, is_bounded
         )

--- a/wkcuber/api/Properties/DatasetProperties.py
+++ b/wkcuber/api/Properties/DatasetProperties.py
@@ -5,7 +5,7 @@ from wkcuber.api.Properties.LayerProperties import (
     SegmentationLayerProperties,
     LayerProperties,
 )
-from wkcuber.api.Properties.ResolutionProperties import WkResolution, TiffResolution
+from wkcuber.api.Properties.ResolutionProperties import WkResolution, Resolution
 from wkcuber.mag import Mag
 
 
@@ -155,11 +155,11 @@ class TiffProperties(Properties):
             for layer in data["dataLayers"]:
                 if layer["category"] == Layer.SEGMENTATION_TYPE:
                     data_layers[layer["name"]] = SegmentationLayerProperties._from_json(
-                        layer, TiffResolution, path
+                        layer, Resolution, path
                     )
                 else:
                     data_layers[layer["name"]] = LayerProperties._from_json(
-                        layer, TiffResolution, path
+                        layer, Resolution, path
                     )
 
             return cls(
@@ -196,5 +196,5 @@ class TiffProperties(Properties):
                 for res in self.data_layers[layer_name].wkw_magnifications
             ]
         ):
-            self.data_layers[layer_name]._add_resolution(TiffResolution(mag))
+            self.data_layers[layer_name]._add_resolution(Resolution(mag))
             self._export_as_json()

--- a/wkcuber/api/Properties/LayerProperties.py
+++ b/wkcuber/api/Properties/LayerProperties.py
@@ -106,7 +106,11 @@ class LayerProperties:
         self._wkw_magnifications.append(resolution)
 
     def _delete_resolution(self, resolution):
-        self._wkw_magnifications.delete(resolution)
+        resolutions_to_delete = [
+            res for res in self._wkw_magnifications if res.mag == Mag(resolution)
+        ]
+        for res in resolutions_to_delete:
+            self._wkw_magnifications.remove(res)
 
     def get_bounding_box(self) -> BoundingBox:
 

--- a/wkcuber/api/Properties/ResolutionProperties.py
+++ b/wkcuber/api/Properties/ResolutionProperties.py
@@ -2,15 +2,6 @@ from wkcuber.mag import Mag
 
 
 class Resolution:
-    def _to_json(self) -> dict:
-        pass
-
-    @classmethod
-    def _from_json(cls, json_data):
-        pass
-
-
-class TiffResolution(Resolution):
     def __init__(self, mag):
         self._mag = Mag(mag)
 
@@ -28,7 +19,7 @@ class TiffResolution(Resolution):
 
 class WkResolution(Resolution):
     def __init__(self, mag, cube_length):
-        self._mag = Mag(mag)
+        super().__init__(mag)
         self._cube_length = cube_length
 
     def _to_json(self) -> dict:


### PR DESCRIPTION
Problem:
- There is a dataset with Mag("2")
- The dataset API would only search on disk for a directory called `.../2` but not for `.../2-2-2`

Solution:
- The dataset API first checks if there is a directory named `.../2`. If not, `.../2-2-2` is also checked