### PR TITLE
Forbid usage of the deprecated parameter 'dtype' for the Dataset API

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1525,3 +1525,14 @@ def test_search_dataset_also_for_long_layer_name():
         mag.read(offset=(10, 10, 10), size=(10, 10, 10)), np.expand_dims(write_data, 0)
     )
     layer.delete_mag("2")
+
+
+def test_outdated_dtype_parameter():
+    delete_dir("./testoutput/outdated_dtype")
+
+    ds = WKDataset.create("./testoutput/outdated_dtype", scale=(1, 1, 1))
+    with pytest.raises(ValueError):
+        ds.get_or_add_layer("color", Layer.COLOR_TYPE, dtype=np.uint8, num_channels=1)
+
+    with pytest.raises(ValueError):
+        ds.add_layer("color", Layer.COLOR_TYPE, dtype=np.uint8, num_channels=1)

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -136,8 +136,10 @@ class AbstractDataset(ABC):
         num_channels=None,
         **kwargs,
     ):
-        if 'dtype' in kwargs:
-            raise ValueError(f"Called Dataset.add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead.")
+        if "dtype" in kwargs:
+            raise ValueError(
+                f"Called Dataset.add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead."
+            )
         if num_channels is None:
             num_channels = 1
 
@@ -197,9 +199,10 @@ class AbstractDataset(ABC):
         num_channels=None,
         **kwargs,
     ) -> Layer:
-        if 'dtype' in kwargs:
+        if "dtype" in kwargs:
             raise ValueError(
-                f"Called Dataset.get_or_add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead.")
+                f"Called Dataset.get_or_add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead."
+            )
         if layer_name in self.layers.keys():
             assert self.properties.data_layers[layer_name].category == category, (
                 f"Cannot get_or_add_layer: The layer '{layer_name}' already exists, but the categories do not match. "

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -8,6 +8,8 @@ import numpy as np
 import os
 import re
 
+from wkcuber.utils import logger
+
 from wkcuber.api.Properties.DatasetProperties import (
     WKProperties,
     TiffProperties,
@@ -134,6 +136,8 @@ class AbstractDataset(ABC):
         num_channels=None,
         **kwargs,
     ):
+        if 'dtype' in kwargs:
+            raise ValueError(f"Called Dataset.add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead.")
         if num_channels is None:
             num_channels = 1
 
@@ -193,6 +197,9 @@ class AbstractDataset(ABC):
         num_channels=None,
         **kwargs,
     ) -> Layer:
+        if 'dtype' in kwargs:
+            raise ValueError(
+                f"Called Dataset.get_or_add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead.")
         if layer_name in self.layers.keys():
             assert self.properties.data_layers[layer_name].category == category, (
                 f"Cannot get_or_add_layer: The layer '{layer_name}' already exists, but the categories do not match. "


### PR DESCRIPTION
In #239 the parameter `dtype` was converted into `dtype_per_channel` and `dtype_per_layer`. This PR asserts that the old parameter `dtype` is no longer used.