### PR TITLE
Improve knossos conversion

### DIFF
--- a/wkcuber/convert_knossos.py
+++ b/wkcuber/convert_knossos.py
@@ -94,7 +94,9 @@ def convert_knossos(
         with get_executor_for_args(args) as executor:
             knossos_cubes = list(source_knossos.list_cubes())
             if len(knossos_cubes) == 0:
-                logging.error("No input KNOSSOS cubes found. Make sure to pass the path which points to a KNOSSOS magnification (e.g., testdata/knossos/color/1).")
+                logging.error(
+                    "No input KNOSSOS cubes found. Make sure to pass the path which points to a KNOSSOS magnification (e.g., testdata/knossos/color/1)."
+                )
                 exit(1)
 
             knossos_cubes.sort()

--- a/wkcuber/convert_knossos.py
+++ b/wkcuber/convert_knossos.py
@@ -94,7 +94,7 @@ def convert_knossos(
         with get_executor_for_args(args) as executor:
             knossos_cubes = list(source_knossos.list_cubes())
             if len(knossos_cubes) == 0:
-                logging.error("No input KNOSSOS cubes found.")
+                logging.error("No input KNOSSOS cubes found. Make sure to pass the path which points to a KNOSSOS magnification (e.g., testdata/knossos/color/1).")
                 exit(1)
 
             knossos_cubes.sort()

--- a/wkcuber/knossos.py
+++ b/wkcuber/knossos.py
@@ -79,7 +79,7 @@ class KnossosDataset:
         return raw_files[0] if len(raw_files) > 0 else None
 
     def list_files(self) -> Iterator[str]:
-        return iglob(path.join(self.root, "**", "*.raw"), recursive=True)
+        return iglob(path.join(self.root, "*", "*", "*", "*.raw"), recursive=True)
 
     def __parse_cube_file_name(self, filename: str) -> Optional[Tuple[int, int, int]]:
         m = CUBE_REGEX.search(filename)


### PR DESCRIPTION
The file listing was able to find arbitrarily nested raw files, but the actual conversion code didn't find the files later and produced only black output. I adapted the code so that the files can only be found when the nesting is as expected (e.g., `testdata/knossos/color/1/x0001/y0001/z0001/file_name.raw`). Otherwise, an error message will be raised like this:

```
# python -m wkcuber.convert_knossos   --jobs 2   --dtype uint8   --layer_name color   --mag 1   testdata/knossos/color/ testoutput/knossos
2021-02-02 13:52:38,430 INFO Using pool of 2 workers.
2021-02-02 13:52:38,431 ERROR No input KNOSSOS cubes found. Make sure to pass the path which points to a KNOSSOS magnification (e.g., testdata/knossos/color/1).
```