### PR TITLE
Calculate max mag from dataset size

### DIFF
--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -266,19 +266,10 @@ def test_downsampling_padding() -> None:
 
 
 def test_default_max_mag() -> None:
-
-    assert calculate_default_max_mag(
-        dataset_size=(65536, 65536, 65536), cube_length=4096
-    ) == Mag([16, 16, 16])
-    assert calculate_default_max_mag(
-        dataset_size=(4096, 4096, 4096), cube_length=4096
-    ) == Mag([16, 16, 16])
-    assert calculate_default_max_mag(
-        dataset_size=(131072, 262144, 262144), cube_length=4096
-    ) == Mag([32, 64, 64])
-    assert calculate_default_max_mag(
-        dataset_size=(32768, 32768, 32768), cube_length=64
-    ) == Mag([512, 512, 512])
-    assert calculate_default_max_mag(
-        dataset_size=(16384, 65536, 65536), cube_length=64
-    ) == Mag([256, 512, 512])
+    assert calculate_default_max_mag(dataset_size=(65536, 65536, 65536)) == Mag(1024)
+    assert calculate_default_max_mag(dataset_size=(4096, 4096, 4096)) == Mag(64)
+    assert calculate_default_max_mag(dataset_size=(131072, 262144, 262144)) == Mag(4096)
+    assert calculate_default_max_mag(dataset_size=(32768, 32768, 32768)) == Mag(512)
+    assert calculate_default_max_mag(dataset_size=(16384, 65536, 65536)) == Mag(1024)
+    assert calculate_default_max_mag(dataset_size=(16384, 65536, 16384)) == Mag(1024)
+    assert calculate_default_max_mag(dataset_size=(256, 256, 256)) == Mag([4, 4, 4])

--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -5,12 +5,12 @@ import numpy as np
 
 from wkcuber.api.Dataset import WKDataset
 from wkcuber.api.Layer import Layer
-from wkcuber.downsampling import calculate_default_max_mag
 from wkcuber.downsampling_utils import (
     InterpolationModes,
     downsample_cube,
     downsample_cube_job,
     get_next_mag,
+    calculate_default_max_mag,
 )
 import wkw
 from wkcuber.mag import Mag

--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from wkcuber.api.Dataset import WKDataset
 from wkcuber.api.Layer import Layer
+from wkcuber.downsampling import calculate_default_max_mag
 from wkcuber.downsampling_utils import (
     InterpolationModes,
     downsample_cube,
@@ -262,3 +263,22 @@ def test_downsampling_padding() -> None:
 
         assert np.array_equal(mag1.get_view().size, expected_size)
         assert np.array_equal(mag1.get_view().global_offset, expected_offset)
+
+
+def test_default_max_mag() -> None:
+
+    assert calculate_default_max_mag(
+        dataset_size=(65536, 65536, 65536), cube_length=4096
+    ) == Mag([16, 16, 16])
+    assert calculate_default_max_mag(
+        dataset_size=(4096, 4096, 4096), cube_length=4096
+    ) == Mag([16, 16, 16])
+    assert calculate_default_max_mag(
+        dataset_size=(131072, 262144, 262144), cube_length=4096
+    ) == Mag([32, 64, 64])
+    assert calculate_default_max_mag(
+        dataset_size=(32768, 32768, 32768), cube_length=64
+    ) == Mag([512, 512, 512])
+    assert calculate_default_max_mag(
+        dataset_size=(16384, 65536, 65536), cube_length=64
+    ) == Mag([256, 512, 512])

--- a/wkcuber/downsampling.py
+++ b/wkcuber/downsampling.py
@@ -173,13 +173,13 @@ if __name__ == "__main__":
     max_mag = None if args.max is None else Mag(args.max)
 
     if args.anisotropic_target_mag or not args.isotropic:
-        anisotropic_target_mag = Mag(args.anisotropic_target_mag)
-
         downsample_mags_anisotropic(
             args.path,
             args.layer_name,
             from_mag,
-            anisotropic_target_mag if args.anisotropic_target_mag else max_mag,
+            Mag(args.anisotropic_target_mag)
+            if args.anisotropic_target_mag
+            else max_mag,
             scale=None,
             interpolation_mode=args.interpolation_mode,
             compress=not args.no_compress,

--- a/wkcuber/downsampling_utils.py
+++ b/wkcuber/downsampling_utils.py
@@ -83,9 +83,7 @@ def calculate_default_max_mag(dataset_size: Tuple[int, int, int]) -> Mag:
     # highest power of 2 larger (or equal) than max_x_y divided by 100
     # The calculated factor will be used for x, y and z here. If anisotropic downsampling takes place,
     # the dimensions can still be downsampled independently according to the scale.
-    return Mag(
-        max(2**math.ceil(math.log(max_x_y / 100, 2)), 4)
-    )  # at least 4
+    return Mag(max(2 ** math.ceil(math.log(max_x_y / 100, 2)), 4))  # at least 4
 
 
 def parse_interpolation_mode(

--- a/wkcuber/downsampling_utils.py
+++ b/wkcuber/downsampling_utils.py
@@ -65,6 +65,27 @@ def get_next_mag(mag: Mag, scale: Optional[Tuple[float, float, float]]) -> Mag:
         )
 
 
+def calculate_virtual_scale_for_target_mag(
+    target_mag: Mag,
+) -> Tuple[float, float, float]:
+    """
+    This scale is not the actual scale of the dataset
+    The virtual scale is used for downsample_mags_anisotropic.
+    """
+    max_target_value = max(list(target_mag.to_array()))
+    scale_array = max_target_value / np.array(target_mag.to_array())
+    return cast(Tuple[float, float, float], tuple(scale_array))
+
+
+def calculate_default_max_mag(dataset_size: Tuple[int, int, int]) -> Mag:
+    # The lowest mag should have a size of ~ 100vx**3
+    max_x_y = max(dataset_size[0], dataset_size[1])
+    # highest power of 2 larger (or equal) than max_x_y divided by 100
+    return Mag(
+        max(int(math.pow(2, math.ceil(math.log(max_x_y / 100, 2)))), 4)
+    )  # at least 4
+
+
 def parse_interpolation_mode(
     interpolation_mode: str, layer_name: str
 ) -> InterpolationModes:

--- a/wkcuber/downsampling_utils.py
+++ b/wkcuber/downsampling_utils.py
@@ -78,11 +78,13 @@ def calculate_virtual_scale_for_target_mag(
 
 
 def calculate_default_max_mag(dataset_size: Tuple[int, int, int]) -> Mag:
-    # The lowest mag should have a size of ~ 100vx**3
+    # The lowest mag should have a size of ~ 100vx**2 per slice
     max_x_y = max(dataset_size[0], dataset_size[1])
     # highest power of 2 larger (or equal) than max_x_y divided by 100
+    # The calculated factor will be used for x, y and z here. If anisotropic downsampling takes place,
+    # the dimensions can still be downsampled independently according to the scale.
     return Mag(
-        max(int(math.pow(2, math.ceil(math.log(max_x_y / 100, 2)))), 4)
+        max(2**math.ceil(math.log(max_x_y / 100, 2)), 4)
     )  # at least 4
 
 


### PR DESCRIPTION
Previously, the default value for `downsampling` was always `512`, regardless of the size of the dataset. This new approach calculates the default value depending on the size of the dataset. The max mag will always be at least `Mag(4)`.

fixes #152 
fixes: #157 (This already worked before for `downsampling.py` but now it also works for `Layer.downsample`)