### PR TITLE
Add compression to Dataset API

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1913,3 +1913,23 @@ def test_bounding_box_on_disk(create_dataset: MagDataset) -> None:
             expected_results.add((bb_offset, file_size))
 
     assert set(bounding_boxes_on_disk) == expected_results
+
+
+def test_compression() -> None:
+    temp_ds_path = Path("testoutput") / "compressed_ds"
+    delete_dir(str(temp_ds_path))
+    copytree(Path("testdata", "simple_wk_dataset"), temp_ds_path)
+
+    mag1 = WKDataset(temp_ds_path).get_layer("color").get_mag(1)
+
+    # writing unaligned data to an uncompressed dataset
+    write_data = (np.random.rand(3, 10, 20, 30) * 255).astype(np.uint8)
+    mag1.write(write_data)
+
+    mag1.compress()
+
+    assert np.array_equal(write_data, mag1.read(size=(10, 20, 30)))
+
+    with pytest.raises(wkw.WKWException):
+        # writing unaligned data to a compressed dataset
+        mag1.write((np.random.rand(3, 10, 20, 30) * 255).astype(np.uint8))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1938,7 +1938,7 @@ def test_bounding_box_on_disk(create_dataset: MagDataset) -> None:
 
 def test_compression() -> None:
     temp_ds_path = Path("testoutput") / "compressed_ds"
-    delete_dir(str(temp_ds_path))
+    delete_dir(temp_ds_path)
     copytree(Path("testdata", "simple_wk_dataset"), temp_ds_path)
 
     mag1 = WKDataset(temp_ds_path).get_layer("color").get_mag(1)

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -233,7 +233,9 @@ class MagDataset:
     def _extract_file_index(self, file_path: Path) -> Tuple[int, int, int]:
         raise NotImplementedError
 
-    def compress(self, target_path: Path = None, args: Namespace = None) -> None:
+    def compress(
+        self, target_path: Union[str, Path] = None, args: Namespace = None
+    ) -> None:
         pass
 
 
@@ -278,9 +280,13 @@ class WKMagDataset(MagDataset):
         zyx_index = [int(el[1:]) for el in file_path.parts]
         return zyx_index[2], zyx_index[1], zyx_index[0]
 
-    def compress(self, target_path: Path = None, args: Namespace = None) -> None:
+    def compress(
+        self, target_path: Union[str, Path] = None, args: Namespace = None
+    ) -> None:
         # The data gets compressed inplace, if target_path is None.
         # Otherwise it is written to target_path/layer_name/mag.
+        if target_path is not None:
+            target_path = Path(target_path)
 
         uncompressed_full_path = (
             Path(self.layer.dataset.path) / self.layer.name / str(Mag(self.name))

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -2,6 +2,10 @@ import glob
 import logging
 import os
 import re
+import shutil
+from argparse import Namespace
+from copy import deepcopy
+from email.header import Header
 from os.path import join
 from pathlib import Path
 from typing import (
@@ -12,14 +16,20 @@ from typing import (
     TYPE_CHECKING,
     TypeVar,
     Generic,
-    Any,
     Generator,
 )
+from uuid import uuid4
 
 from wkw import wkw
 import numpy as np
 
-from wkcuber.utils import ceil_div_np, convert_mag1_size, convert_mag1_offset
+from wkcuber.compress_utils import compress_file_job
+from wkcuber.utils import (
+    convert_mag1_size,
+    convert_mag1_offset,
+    get_executor_for_args,
+    wait_and_ensure_success,
+)
 
 if TYPE_CHECKING:
     from wkcuber.api.Layer import (
@@ -225,6 +235,9 @@ class MagDataset:
     def _extract_file_index(self, file_path: str) -> Tuple[int, int, int]:
         raise NotImplementedError
 
+    def compress(self, target_path: Path = None, args: Namespace = None) -> None:
+        pass
+
 
 class WKMagDataset(MagDataset):
     header: wkw.Header
@@ -266,6 +279,61 @@ class WKMagDataset(MagDataset):
     def _extract_file_index(self, file_path: str) -> Tuple[int, int, int]:
         zyx_index = [int(el[1:]) for el in file_path.split("/")]
         return zyx_index[2], zyx_index[1], zyx_index[0]
+
+    def compress(self, target_path: Path = None, args: Namespace = None) -> None:
+        # The data gets compressed inplace, if target_path is None.
+        # Otherwise it is written to target_path/layer_name/mag.
+
+        uncompressed_path = (
+            Path(self.layer.dataset.path) / self.layer.name / str(Mag(self.name))
+        )
+        compressed_path = (
+            target_path
+            if target_path is not None
+            else Path("{}.compress-{}".format(self.layer.dataset.path, uuid4()))
+        )
+
+        if compressed_path.exists():
+            logging.error("Target path '{}' already exists".format(compressed_path))
+            exit(1)
+
+        logging.info(
+            "Compressing mag {0} in '{1}'".format(self.name, str(uncompressed_path))
+        )
+
+        was_opened = self.view._is_opened
+        if not was_opened:
+            self.open()  # opening the view is necessary to set the dataset
+        assert self.view.dataset is not None
+
+        # create empty wkw.Dataset
+        self.view.dataset.compress(str(compressed_path / self.layer.name / self.name))
+
+        # compress all files to and move them to 'compressed_path'
+        with get_executor_for_args(args) as executor:
+            job_args = []
+            for file in self.view.dataset.list_files():
+                rel_file = Path(file).relative_to(self.layer.dataset.path)
+                job_args.append((Path(file), compressed_path / rel_file))
+
+            wait_and_ensure_success(
+                executor.map_to_futures(compress_file_job, job_args)
+            )
+
+        logging.info("Mag {0} successfully compressed".format(self.name))
+
+        if not was_opened:
+            self.close()
+
+        if target_path is None:
+            shutil.rmtree(uncompressed_path)
+            shutil.move(
+                str(compressed_path / self.layer.name / self.name), uncompressed_path
+            )
+            shutil.rmtree(compressed_path)
+
+            # update the handle to the new dataset
+            self.view = self.get_view(offset=(0, 0, 0), is_bounded=False)
 
 
 TiffLayerT = TypeVar("TiffLayerT", bound="GenericTiffLayer")

--- a/wkcuber/compress.py
+++ b/wkcuber/compress.py
@@ -1,23 +1,19 @@
-import time
-import wkw
+from pathlib import Path
+
 import shutil
 import logging
 from argparse import ArgumentParser, Namespace
 from os import path, makedirs
-from uuid import uuid4
+
+from wkcuber.api.Dataset import WKDataset
 from .mag import Mag
 
 from .utils import (
     add_verbose_flag,
-    open_wkw,
-    WkwDatasetInfo,
     add_distribution_flags,
-    get_executor_for_args,
-    wait_and_ensure_success,
     setup_logging,
 )
-from .metadata import detect_resolutions, convert_element_class_to_dtype
-from typing import List, Tuple
+from typing import List
 
 BACKUP_EXT = ".bak"
 
@@ -53,28 +49,6 @@ def create_parser() -> ArgumentParser:
     return parser
 
 
-def compress_file_job(args: Tuple[str, str]) -> None:
-    source_path, target_path = args
-    try:
-        logging.debug("Compressing '{}' to '{}'".format(source_path, target_path))
-        ref_time = time.time()
-
-        makedirs(path.dirname(target_path), exist_ok=True)
-        wkw.File.compress(source_path, target_path)
-
-        if not path.exists(target_path):
-            raise Exception("Did not create compressed file {}".format(target_path))
-
-        logging.debug(
-            "Compressing of '{}' took {:.8f}s".format(
-                source_path, time.time() - ref_time
-            )
-        )
-    except Exception as exc:
-        logging.error("Compressing of '{}' failed with {}".format(source_path, exc))
-        raise exc
-
-
 def compress_mag(
     source_path: str,
     layer_name: str,
@@ -82,45 +56,15 @@ def compress_mag(
     mag: Mag,
     args: Namespace = None,
 ) -> None:
-    if path.exists(path.join(target_path, layer_name, str(mag))):
-        logging.error("Target path '{}' already exists".format(target_path))
-        exit(1)
-
-    if args is not None and hasattr(args, "dtype"):
-        header = wkw.Header(convert_element_class_to_dtype(args.dtype))
-    else:
-        header = None
-    source_wkw_info = WkwDatasetInfo(source_path, layer_name, mag, header)
-    target_mag_path = path.join(target_path, layer_name, str(mag))
-    logging.info("Compressing mag {0} in '{1}'".format(str(mag), target_mag_path))
-
-    with open_wkw(source_wkw_info) as source_wkw:
-        source_wkw.compress(target_mag_path)
-        with get_executor_for_args(args) as executor:
-            job_args = []
-            for file in source_wkw.list_files():
-                rel_file = path.relpath(file, source_wkw.root)
-                job_args.append((file, path.join(target_mag_path, rel_file)))
-
-            wait_and_ensure_success(
-                executor.map_to_futures(compress_file_job, job_args)
-            )
-
-    logging.info("Mag {0} successfully compressed".format(str(mag)))
+    WKDataset(source_path).get_layer(layer_name).get_mag(mag).compress(
+        target_path=Path(target_path), args=args
+    )
 
 
 def compress_mag_inplace(
     target_path: str, layer_name: str, mag: Mag, args: Namespace = None
 ) -> None:
-    compress_target_path = "{}.compress-{}".format(target_path, uuid4())
-    compress_mag(target_path, layer_name, compress_target_path, mag, args)
-
-    shutil.rmtree(path.join(target_path, layer_name, str(mag)))
-    shutil.move(
-        path.join(compress_target_path, layer_name, str(mag)),
-        path.join(target_path, layer_name, str(mag)),
-    )
-    shutil.rmtree(compress_target_path)
+    WKDataset(target_path).get_layer(layer_name).get_mag(mag).compress(args=args)
 
 
 def compress_mags(
@@ -135,12 +79,13 @@ def compress_mags(
     else:
         target = target_path
 
+    layer = WKDataset(source_path).get_layer(layer_name)
     if mags is None:
-        mags = list(detect_resolutions(source_path, layer_name))
-    mags.sort()
+        mags = [Mag(mag_name) for mag_name in layer.mags.keys()]
 
-    for mag in mags:
-        compress_mag(source_path, layer_name, target, mag, args)
+    for mag_name, mag_ds in WKDataset(source_path).get_layer(layer_name).mags.items():
+        if Mag(mag_name) in mags:
+            mag_ds.compress(target_path=Path(target), args=args)
 
     if target_path is None:
         makedirs(path.join(source_path + BACKUP_EXT, layer_name), exist_ok=True)

--- a/wkcuber/compress.py
+++ b/wkcuber/compress.py
@@ -1,11 +1,9 @@
-import time
 from pathlib import Path
 
-import wkw
 import shutil
 import logging
 from argparse import ArgumentParser, Namespace
-from os import path, makedirs
+from os import makedirs
 
 from wkcuber.api.Dataset import WKDataset
 from .mag import Mag

--- a/wkcuber/compress_utils.py
+++ b/wkcuber/compress_utils.py
@@ -1,0 +1,29 @@
+import time
+import logging
+from os import path, makedirs
+from pathlib import Path
+from typing import Tuple
+
+import wkw
+
+
+def compress_file_job(args: Tuple[Path, Path]) -> None:
+    source_path, target_path = args
+    try:
+        logging.debug("Compressing '{}' to '{}'".format(source_path, target_path))
+        ref_time = time.time()
+
+        makedirs(path.dirname(target_path), exist_ok=True)
+        wkw.File.compress(str(source_path), str(target_path))
+
+        if not path.exists(target_path):
+            raise Exception("Did not create compressed file {}".format(target_path))
+
+        logging.debug(
+            "Compressing of '{}' took {:.8f}s".format(
+                source_path, time.time() - ref_time
+            )
+        )
+    except Exception as exc:
+        logging.error("Compressing of '{}' failed with {}".format(source_path, exc))
+        raise exc


### PR DESCRIPTION
The dataset API can now compress `MagDataset` (this is currently only implemented for `WKMagDataset`), by calling `.compress()`. This compresses the data in-place. Optionally a `target_path` can be specified.

fixes: #288 