### PR TITLE
Support more types for 'dtype' in Dataset.get_or_add

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -681,6 +681,13 @@ def test_get_or_add_layer() -> None:
         pass
 
 
+def test_get_or_add_layer_idempotence() -> None:
+    delete_dir(TESTOUTPUT_DIR / "wk_dataset")
+    ds = WKDataset.create(TESTOUTPUT_DIR / "wk_dataset", scale=(1, 1, 1))
+    ds.get_or_add_layer("color2", "color", np.uint8).get_or_add_mag("1")
+    ds.get_or_add_layer("color2", "color", np.uint8).get_or_add_mag("1")
+
+
 def test_get_or_add_mag_for_wk() -> None:
     delete_dir(TESTOUTPUT_DIR / "wk_dataset")
 

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -52,6 +52,28 @@ def convert_dtypes(
     return "".join(converted_dtype_parts)
 
 
+def normalize_dtype_per_channel(
+    dtype_per_channel: Union[str, np.dtype, type]
+) -> np.dtype:
+    try:
+        return np.dtype(dtype_per_channel)
+    except TypeError as e:
+        raise TypeError(
+            "Cannot add layer. The specified 'dtype_per_channel' must be a valid dtype. "
+            + str(e)
+        )
+
+
+def normalize_dtype_per_layer(
+    dtype_per_layer: Union[str, np.dtype, type]
+) -> Union[str, np.dtype]:
+    try:
+        dtype_per_layer = str(np.dtype(dtype_per_layer))
+    except Exception:
+        pass  # casting to np.dtype fails if the user specifies a special dtype like "uint24"
+    return dtype_per_layer
+
+
 def dtype_per_layer_to_dtype_per_channel(
     dtype_per_layer: Union[str, np.dtype], num_channels: int
 ) -> np.dtype:
@@ -147,8 +169,8 @@ class AbstractDataset(Generic[LayerT]):
         self,
         layer_name: str,
         category: str,
-        dtype_per_layer: Union[str, np.dtype] = None,
-        dtype_per_channel: Union[str, np.dtype] = None,
+        dtype_per_layer: Union[str, np.dtype, type] = None,
+        dtype_per_channel: Union[str, np.dtype, type] = None,
         num_channels: int = None,
         **kwargs: Any,
     ) -> LayerT:
@@ -164,21 +186,12 @@ class AbstractDataset(Generic[LayerT]):
                 "Cannot add layer. Specifying both 'dtype_per_layer' and 'dtype_per_channel' is not allowed"
             )
         elif dtype_per_channel is not None:
-            try:
-                dtype_per_channel = np.dtype(dtype_per_channel)
-            except TypeError as e:
-                raise TypeError(
-                    "Cannot add layer. The specified 'dtype_per_channel' must be a valid dtype. "
-                    + str(e)
-                )
+            dtype_per_channel = normalize_dtype_per_channel(dtype_per_channel)
             dtype_per_layer = dtype_per_channel_to_dtype_per_layer(
                 dtype_per_channel, num_channels
             )
         elif dtype_per_layer is not None:
-            try:
-                dtype_per_layer = str(np.dtype(dtype_per_layer))
-            except Exception:
-                pass  # casting to np.dtype fails if the user specifies a special dtype like "uint24"
+            dtype_per_layer = normalize_dtype_per_layer(dtype_per_layer)
             dtype_per_channel = dtype_per_layer_to_dtype_per_channel(
                 dtype_per_layer, num_channels
             )
@@ -210,8 +223,8 @@ class AbstractDataset(Generic[LayerT]):
         self,
         layer_name: str,
         category: str,
-        dtype_per_layer: Union[str, np.dtype] = None,
-        dtype_per_channel: Union[str, np.dtype] = None,
+        dtype_per_layer: Union[str, np.dtype, type] = None,
+        dtype_per_channel: Union[str, np.dtype, type] = None,
         num_channels: int = None,
         **kwargs: Any,
     ) -> LayerT:
@@ -233,6 +246,12 @@ class AbstractDataset(Generic[LayerT]):
                 + f"The category of the existing layer is '{self.properties.data_layers[layer_name].category}' "
                 + f"and the passed parameter is '{category}'."
             )
+
+            if dtype_per_channel is not None:
+                dtype_per_channel = normalize_dtype_per_channel(dtype_per_channel)
+
+            if dtype_per_layer is not None:
+                dtype_per_layer = normalize_dtype_per_layer(dtype_per_layer)
 
             if dtype_per_channel is not None or dtype_per_layer is not None:
                 dtype_per_channel = (


### PR DESCRIPTION
The actual cause of the error is that `np.uint8` is neither a `str`, not a `np.dtype` (`np.uint8 != np.dtype('uint8')`). While `add_layer` handled this correctly (even though the type was not 'officially' supported), `get_or_add` failed. I fixed the code of `get_or_add` and added `type` as an allowed type.

fixes #303 