### PR TITLE
Save bounding box correctly after downsampling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,16 +7,30 @@ and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MIC
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.1...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.6...HEAD)
 
 ### Breaking Changes in Config & CLI
-- The interface for `downsamping` was completely reworked. The flags `anisotropic_target_mag` and `isotropic` are now deprecated. Use `max` and `sampling_mode` instead. [#304](https://github.com/scalableminds/webknossos-cuber/pull/304)
 
 ### Added
 
 ### Changed
 
 ### Fixed
+
+## [0.6.6](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.6) - 2021-05-14
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.5...v0.6.6)
+
+### Fixed
+- After downsampling data, the bounding box gets saved correctly to the `datasource-properties.json`.
+
+## [0.6.5](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.5) - 2021-05-12
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.4...v0.6.5)
+
+### Breaking Changes in Config & CLI
+- The interface for `downsampling` was completely reworked. The flags `anisotropic_target_mag` and `isotropic` are now deprecated. Use `max` and `sampling_mode` instead. [#304](https://github.com/scalableminds/webknossos-cuber/pull/304)
+
+### Changed
+- Relaxes the constraint that all input files need to have the same type when auto-converting. [#317](https://github.com/scalableminds/webknossos-cuber/pull/317)
 
 ## [0.6.4](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.4) - 2021-05-12
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.3...v0.6.4)

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,7 +21,8 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.5...v0.6.6)
 
 ### Fixed
-- After downsampling data, the bounding box gets saved correctly to the `datasource-properties.json`.
+- After downsampling data, the bounding box gets saved correctly to the `datasource-properties.json`. [#320](https://github.com/scalableminds/webknossos-cuber/pull/320)
+
 
 ## [0.6.5](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.5) - 2021-05-12
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.4...v0.6.5)

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -73,7 +73,7 @@ class MagDataset:
         offset: Tuple[int, int, int] = (0, 0, 0),
         size: Tuple[int, int, int] = None,
     ) -> np.array:
-        return self.view.read(offset, size)
+        return self.get_view().read(offset, size)
 
     def write(
         self,
@@ -82,7 +82,7 @@ class MagDataset:
         allow_compressed_write: bool = False,
     ) -> None:
         self._assert_valid_num_channels(data.shape)
-        self.view.write(data, offset, allow_compressed_write)
+        self.get_view().write(data, offset, allow_compressed_write)
         layer_properties = self.layer.dataset.properties.data_layers[self.layer.name]
         current_offset_in_mag1 = layer_properties.get_bounding_box_offset()
         current_size_in_mag1 = layer_properties.get_bounding_box_size()

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -154,7 +154,7 @@ class MagDataset:
             )
         )
 
-        properties_offset_in_current_mag = convert_mag1_size(
+        properties_offset_in_current_mag = convert_mag1_offset(
             mag1_offset_in_properties, Mag(self.name)
         )
 

--- a/wkcuber/api/MagDataset.py
+++ b/wkcuber/api/MagDataset.py
@@ -73,7 +73,7 @@ class MagDataset:
         offset: Tuple[int, int, int] = (0, 0, 0),
         size: Tuple[int, int, int] = None,
     ) -> np.array:
-        return self.get_view().read(offset, size)
+        return self.view.read(offset, size)
 
     def write(
         self,
@@ -82,7 +82,7 @@ class MagDataset:
         allow_compressed_write: bool = False,
     ) -> None:
         self._assert_valid_num_channels(data.shape)
-        self.get_view().write(data, offset, allow_compressed_write)
+        self.view.write(data, offset, allow_compressed_write)
         layer_properties = self.layer.dataset.properties.data_layers[self.layer.name]
         current_offset_in_mag1 = layer_properties.get_bounding_box_offset()
         current_size_in_mag1 = layer_properties.get_bounding_box_size()


### PR DESCRIPTION
### Description:
- after downsampling, padded bounding box should not be persisted to disk

### Issues:
- fixes #310 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
