### PR TITLE
Dataset API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ instance/
 # Sphinx documentation
 docs/_build/
 
+# docs
+/docs/api
+
 # PyBuilder
 target/
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
+- Added `docs/api.sh` which opens a server displaying the docs. It can also be used to persist the html to `docs/api` by invoking `docs/api.sh --persist`. [#322](https://github.com/scalableminds/webknossos-cuber/pull/322)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ tests/scripts/all_tests.sh
 
 PyPi releases are automatically pushed when creating a new Git tag/Github release. 
 
+## Generate the API documentation
+Run `docs/api.sh` to open a server displaying the API docs. `docs/api.sh --persist` persists the html to `docs/api`.
+
 ## Test Data Credits
 Excerpts for testing purposes have been sampled from:
 - Dow Jacobo Hossain Siletti Hudspeth (2018). **Connectomics of the zebrafish's lateral-line neuromast reveals wiring and miswiring in a simple microcircuit.** eLife. [DOI:10.7554/eLife.33988](https://elifesciences.org/articles/33988)

--- a/docs/api.sh
+++ b/docs/api.sh
@@ -6,7 +6,7 @@ PROJECT_DIR="$(dirname "$(dirname "$0")")"
 cd "$PROJECT_DIR/."
 
 if [ $# -eq 1 ] && [ "$1" = "--persist" ]; then
-    pdoc wkcuber  -o docs/api
+    pdoc ./wkcuber  -o docs/api
 else
-    pdoc wkcuber  -p 8095 -h 0.0.0.0
+    pdoc ./wkcuber  -p 8095 -h 0.0.0.0
 fi

--- a/docs/api.sh
+++ b/docs/api.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+set -Eeo pipefail
+
+PROJECT_DIR="$(dirname "$(dirname "$0")")"
+
+cd "$PROJECT_DIR/."
+
+if [ $# -eq 1 ] && [ "$1" = "--persist" ]; then
+    pdoc wkcuber  -o docs/api
+else
+    pdoc wkcuber  -p 8095 -h 0.0.0.0
+fi

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,17 @@ typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpyth
 wrapt = ">=1.11,<2.0"
 
 [[package]]
+name = "astunparse"
+version = "1.6.3"
+description = "An AST unparser for Python"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.6.1,<2.0"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -237,6 +248,20 @@ requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
+name = "jinja2"
+version = "3.0.0"
+description = "A very fast and expressive template engine."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+MarkupSafe = ">=2.0.0rc2"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
 name = "joblib"
 version = "1.0.0"
 description = "Lightweight pipelining with Python functions"
@@ -259,6 +284,14 @@ description = "A fast and thorough lazy object proxy."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "markupsafe"
+version = "2.0.0"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "matplotlib"
@@ -390,6 +423,23 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pdoc"
+version = "6.6.0"
+description = "API Documentation for Python Projects"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+astunparse = {version = "*", markers = "python_version < \"3.9\""}
+Jinja2 = ">=2.11.0"
+MarkupSafe = "*"
+pygments = "*"
+
+[package.extras]
+dev = ["flake8", "hypothesis", "mypy", "pytest", "pytest-cov", "pytest-timeout", "tox", "twine", "wheel"]
+
+[[package]]
 name = "pillow"
 version = "6.2.2"
 description = "Python Imaging Library (Fork)"
@@ -437,6 +487,14 @@ description = "C parser in Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pygments"
+version = "2.9.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "pylint"
@@ -696,7 +754,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "beeb02d2939db6497a17897fc8f8c46eafcd6be042ad27264ff524bb27f31a26"
+content-hash = "cb687342a05629d9872bc9aedf8d089a33038dfd162e605f4570db2aad81b0e3"
 
 [metadata.files]
 appdirs = [
@@ -706,6 +764,10 @@ appdirs = [
 astroid = [
     {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},
     {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
+]
+astunparse = [
+    {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
+    {file = "astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -756,7 +818,6 @@ cffi = [
     {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
     {file = "cffi-1.14.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd"},
     {file = "cffi-1.14.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a"},
-    {file = "cffi-1.14.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:7ef7d4ced6b325e92eb4d3502946c78c5367bc416398d387b39591532536734e"},
     {file = "cffi-1.14.4-cp39-cp39-win32.whl", hash = "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3"},
     {file = "cffi-1.14.4-cp39-cp39-win_amd64.whl", hash = "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b"},
     {file = "cffi-1.14.4.tar.gz", hash = "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"},
@@ -837,6 +898,10 @@ isort = [
     {file = "isort-5.7.0-py3-none-any.whl", hash = "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"},
     {file = "isort-5.7.0.tar.gz", hash = "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e"},
 ]
+jinja2 = [
+    {file = "Jinja2-3.0.0-py3-none-any.whl", hash = "sha256:2f2de5285cf37f33d33ecd4a9080b75c87cd0c1994d5a9c6df17131ea1f049c6"},
+    {file = "Jinja2-3.0.0.tar.gz", hash = "sha256:ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5"},
+]
 joblib = [
     {file = "joblib-1.0.0-py3-none-any.whl", hash = "sha256:75ead23f13484a2a414874779d69ade40d4fa1abe62b222a23cd50d4bc822f6f"},
     {file = "joblib-1.0.0.tar.gz", hash = "sha256:7ad866067ac1fdec27d51c8678ea760601b70e32ff1881d4dc8e1171f2b64b24"},
@@ -897,6 +962,42 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2efaeb1baff547063bad2b2893a8f5e9c459c4624e1a96644bbba08910ae34e0"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:441ce2a8c17683d97e06447fcbccbdb057cbf587c78eb75ae43ea7858042fe2c"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:45535241baa0fc0ba2a43961a1ac7562ca3257f46c4c3e9c0de38b722be41bd1"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:90053234a6479738fd40d155268af631c7fca33365f964f2208867da1349294b"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3b54a9c68995ef4164567e2cd1a5e16db5dac30b2a50c39c82db8d4afaf14f63"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f58b5ba13a5689ca8317b98439fccfbcc673acaaf8241c1869ceea40f5d585bf"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-win32.whl", hash = "sha256:a00dce2d96587651ef4fa192c17e039e8cfab63087c67e7d263a5533c7dad715"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:007dc055dbce5b1104876acee177dbfd18757e19d562cd440182e1f492e96b95"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a08cd07d3c3c17cd33d9e66ea9dee8f8fc1c48e2d11bd88fd2dc515a602c709b"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3c352ff634e289061711608f5e474ec38dbaa21e3e168820d53d5f4015e5b91b"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:32200f562daaab472921a11cbb63780f1654552ae49518196fc361ed8e12e901"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:fef86115fdad7ae774720d7103aa776144cf9b66673b4afa9bcaa7af990ed07b"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e79212d09fc0e224d20b43ad44bb0a0a3416d1e04cf6b45fed265114a5d43d20"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:79b2ae94fa991be023832e6bcc00f41dbc8e5fe9d997a02db965831402551730"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-win32.whl", hash = "sha256:3261fae28155e5c8634dd7710635fe540a05b58f160cef7713c7700cb9980e66"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e4570d16f88c7f3032ed909dc9e905a17da14a1c4cfd92608e3fda4cb1208bbd"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8f806bfd0f218477d7c46a11d3e52dc7f5fdfaa981b18202b7dc84bbc287463b"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e77e4b983e2441aff0c0d07ee711110c106b625f440292dfe02a2f60c8218bd6"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:031bf79a27d1c42f69c276d6221172417b47cb4b31cdc73d362a9bf5a1889b9f"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:83cf0228b2f694dcdba1374d5312f2277269d798e65f40344964f642935feac1"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4cc563836f13c57f1473bc02d1e01fc37bab70ad4ee6be297d58c1d66bc819bf"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d00a669e4a5bec3ee6dbeeeedd82a405ced19f8aeefb109a012ea88a45afff96"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-win32.whl", hash = "sha256:161d575fa49395860b75da5135162481768b11208490d5a2143ae6785123e77d"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:58bc9fce3e1557d463ef5cee05391a05745fd95ed660f23c1742c711712c0abb"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3fb47f97f1d338b943126e90b79cad50d4fcfa0b80637b5a9f468941dbbd9ce5"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dab0c685f21f4a6c95bfc2afd1e7eae0033b403dd3d8c1b6d13a652ada75b348"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:664832fb88b8162268928df233f4b12a144a0c78b01d38b81bdcf0fc96668ecb"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:df561f65049ed3556e5b52541669310e88713fdae2934845ec3606f283337958"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:24bbc3507fb6dfff663af7900a631f2aca90d5a445f272db5fc84999fa5718bc"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:87de598edfa2230ff274c4de7fcf24c73ffd96208c8e1912d5d0fee459767d75"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a19d39b02a24d3082856a5b06490b714a9d4179321225bbf22809ff1e1887cc8"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-win32.whl", hash = "sha256:4aca81a687975b35e3e80bcf9aa93fe10cd57fac37bf18b2314c186095f57e05"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:70820a1c96311e02449591cbdf5cd1c6a34d5194d5b55094ab725364375c9eb2"},
+    {file = "MarkupSafe-2.0.0.tar.gz", hash = "sha256:4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527"},
 ]
 matplotlib = [
     {file = "matplotlib-3.3.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b2a5e1f637a92bb6f3526cc54cc8af0401112e81ce5cba6368a1b7908f9e18bc"},
@@ -1014,6 +1115,9 @@ pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
+pdoc = [
+    {file = "pdoc-6.6.0-py3-none-any.whl", hash = "sha256:d0b8cfe21fbdd243feaad133a40c1af3e98c2333f5fc2f221144961ec2d2c491"},
+]
 pillow = [
     {file = "Pillow-6.2.2-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:834dd023b7f987d6b700ad93dc818098d7eb046bd445e9992b3093c6f9d7a95f"},
     {file = "Pillow-6.2.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:d3a98444a00b4643b22b0685dbf9e0ddcaf4ebfd4ea23f84f228adf5a0765bb2"},
@@ -1087,6 +1191,10 @@ py = [
 pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+]
+pygments = [
+    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
+    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
 ]
 pylint = [
     {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},
@@ -1203,35 +1311,23 @@ scikit-image = [
 scikit-learn = [
     {file = "scikit-learn-0.24.1.tar.gz", hash = "sha256:a0334a1802e64d656022c3bfab56a73fbd6bf4b1298343f3688af2151810bbdf"},
     {file = "scikit_learn-0.24.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:9bed8a1ef133c8e2f13966a542cb8125eac7f4b67dcd234197c827ba9c7dd3e0"},
-    {file = "scikit_learn-0.24.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a36e159a0521e13bbe15ca8c8d038b3a1dd4c7dad18d276d76992e03b92cf643"},
-    {file = "scikit_learn-0.24.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c658432d8a20e95398f6bb95ff9731ce9dfa343fdf21eea7ec6a7edfacd4b4d9"},
     {file = "scikit_learn-0.24.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9dfa564ef27e8e674aa1cc74378416d580ac4ede1136c13dd555a87996e13422"},
     {file = "scikit_learn-0.24.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:9c6097b6a9b2bafc5e0f31f659e6ab5e131383209c30c9e978c5b8abdac5ed2a"},
-    {file = "scikit_learn-0.24.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:5580eba7345a4d3b097be2f067cc71a306c44bab19e8717a30361f279c929bea"},
     {file = "scikit_learn-0.24.1-cp36-cp36m-win32.whl", hash = "sha256:7b04691eb2f41d2c68dbda8d1bd3cb4ef421bdc43aaa56aeb6c762224552dfb6"},
     {file = "scikit_learn-0.24.1-cp36-cp36m-win_amd64.whl", hash = "sha256:1adf483e91007a87171d7ce58c34b058eb5dab01b5fee6052f15841778a8ecd8"},
     {file = "scikit_learn-0.24.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:ddb52d088889f5596bc4d1de981f2eca106b58243b6679e4782f3ba5096fd645"},
-    {file = "scikit_learn-0.24.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a29460499c1e62b7a830bb57ca42e615375a6ab1bcad053cd25b493588348ea8"},
-    {file = "scikit_learn-0.24.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0567a2d29ad08af98653300c623bd8477b448fe66ced7198bef4ed195925f082"},
     {file = "scikit_learn-0.24.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:99349d77f54e11f962d608d94dfda08f0c9e5720d97132233ebdf35be2858b2d"},
     {file = "scikit_learn-0.24.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:83b21ff053b1ff1c018a2d24db6dd3ea339b1acfbaa4d9c881731f43748d8b3b"},
-    {file = "scikit_learn-0.24.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:abe835a851610f87201819cb315f8d554e1a3e8128912783a31e87264ba5ffb7"},
     {file = "scikit_learn-0.24.1-cp37-cp37m-win32.whl", hash = "sha256:c3deb3b19dd9806acf00cf0d400e84562c227723013c33abefbbc3cf906596e9"},
     {file = "scikit_learn-0.24.1-cp37-cp37m-win_amd64.whl", hash = "sha256:d54dbaadeb1425b7d6a66bf44bee2bb2b899fe3e8850b8e94cfb9c904dcb46d0"},
     {file = "scikit_learn-0.24.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:3c4f07f47c04e81b134424d53c3f5e16dfd7f494e44fd7584ba9ce9de2c5e6c1"},
-    {file = "scikit_learn-0.24.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c13ebac42236b1c46397162471ea1c46af68413000e28b9309f8c05722c65a09"},
-    {file = "scikit_learn-0.24.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4ddd2b6f7449a5d539ff754fa92d75da22de261fd8fdcfb3596799fadf255101"},
     {file = "scikit_learn-0.24.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:826b92bf45b8ad80444814e5f4ac032156dd481e48d7da33d611f8fe96d5f08b"},
     {file = "scikit_learn-0.24.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:259ec35201e82e2db1ae2496f229e63f46d7f1695ae68eef9350b00dc74ba52f"},
-    {file = "scikit_learn-0.24.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:9599a3f3bf33f73fed0fe06d1dfa4e6081365a58c1c807acb07271be0dce9733"},
     {file = "scikit_learn-0.24.1-cp38-cp38-win32.whl", hash = "sha256:8772b99d683be8f67fcc04789032f1b949022a0e6880ee7b75a7ec97dbbb5d0b"},
     {file = "scikit_learn-0.24.1-cp38-cp38-win_amd64.whl", hash = "sha256:ed9d65594948678827f4ff0e7ae23344e2f2b4cabbca057ccaed3118fdc392ca"},
     {file = "scikit_learn-0.24.1-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:8aa1b3ac46b80eaa552b637eeadbbce3be5931e4b5002b964698e33a1b589e1e"},
-    {file = "scikit_learn-0.24.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c7f4eb77504ac586d8ac1bde1b0c04b504487210f95297235311a0ab7edd7e38"},
-    {file = "scikit_learn-0.24.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:087dfede39efb06ab30618f9ab55a0397f29c38d63cd0ab88d12b500b7d65fd7"},
     {file = "scikit_learn-0.24.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:895dbf2030aa7337649e36a83a007df3c9811396b4e2fa672a851160f36ce90c"},
     {file = "scikit_learn-0.24.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:9a24d1ccec2a34d4cd3f2a1f86409f3f5954cc23d4d2270ba0d03cf018aa4780"},
-    {file = "scikit_learn-0.24.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:54be0a60a5a35005ad69c75902e0f5c9f699db4547ead427e97ef881c3242e6f"},
     {file = "scikit_learn-0.24.1-cp39-cp39-win32.whl", hash = "sha256:fab31f48282ebf54dd69f6663cd2d9800096bad1bb67bbc9c9ac84eb77b41972"},
     {file = "scikit_learn-0.24.1-cp39-cp39-win_amd64.whl", hash = "sha256:4562dcf4793e61c5d0f89836d07bc37521c3a1889da8f651e2c326463c4bd697"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -424,7 +424,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pdoc"
-version = "6.6.0"
+version = "7.0.1"
 description = "API Documentation for Python Projects"
 category = "dev"
 optional = false
@@ -437,7 +437,7 @@ MarkupSafe = "*"
 pygments = "*"
 
 [package.extras]
-dev = ["flake8", "hypothesis", "mypy", "pytest", "pytest-cov", "pytest-timeout", "tox", "twine", "wheel"]
+dev = ["flake8", "hypothesis", "mypy", "pytest", "pytest-cov", "pytest-timeout", "tox"]
 
 [[package]]
 name = "pillow"
@@ -754,7 +754,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "cb687342a05629d9872bc9aedf8d089a33038dfd162e605f4570db2aad81b0e3"
+content-hash = "4cf3b64baeb282d9177d76cf24803cb7e11bdb29ea390963538678d6322dbfd8"
 
 [metadata.files]
 appdirs = [
@@ -1116,7 +1116,7 @@ pathspec = [
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pdoc = [
-    {file = "pdoc-6.6.0-py3-none-any.whl", hash = "sha256:d0b8cfe21fbdd243feaad133a40c1af3e98c2333f5fc2f221144961ec2d2c491"},
+    {file = "pdoc-7.0.1-py3-none-any.whl", hash = "sha256:70d0400ccc42e9149a09670af3cc839ad3455ed01f2fd1ad84c9fbb7c30f1bf5"},
 ]
 pillow = [
     {file = "Pillow-6.2.2-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:834dd023b7f987d6b700ad93dc818098d7eb046bd445e9992b3093c6f9d7a95f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ black = "^20.8b1"
 pytest = "^6.2.1"
 setuptools-scm = "^3.3.3"
 mypy = "^0.800"
-pdoc = "*"
+pdoc = "^7.0.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ black = "^20.8b1"
 pytest = "^6.2.1"
 setuptools-scm = "^3.3.3"
 mypy = "^0.800"
+pdoc = "*"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -27,7 +27,7 @@ from os import path, makedirs
 
 from wkcuber.api.Layer import Layer
 from wkcuber.api.MagDataset import (
-    find_mag_path_on_disk,
+    _find_mag_path_on_disk,
     MagDataset,
     TiledTiffMagDataset,
 )

--- a/wkcuber/__init__.py
+++ b/wkcuber/__init__.py
@@ -1,7 +1,14 @@
+"""
+# wkcuber
+
+This module provides fundamental methods to modify or interact with datasets.
+The documentation is currently limeted to `wkcuber.api`. For information regarding the other functionalities,
+refer to the `README.md`.
+"""
+
 from .api.Dataset import WKDataset
 from .cubing import cubing
 from .downsampling import downsample_mags
 from .compress import compress_mag
 from .mag import Mag
 from .metadata import write_webknossos_metadata
-

--- a/wkcuber/__init__.py
+++ b/wkcuber/__init__.py
@@ -2,7 +2,7 @@
 # wkcuber
 
 This module provides fundamental methods to modify or interact with datasets.
-The documentation is currently limeted to `wkcuber.api`. For information regarding the other functionalities,
+The documentation is currently limited to the Dataset API in `wkcuber.api`. For information regarding the other functionalities,
 refer to the `README.md`.
 """
 

--- a/wkcuber/__init__.py
+++ b/wkcuber/__init__.py
@@ -4,3 +4,4 @@ from .downsampling import downsample_mags
 from .compress import compress_mag
 from .mag import Mag
 from .metadata import write_webknossos_metadata
+

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -212,7 +212,7 @@ class AbstractDataset(Generic[LayerT]):
         When creating a `wkcuber.api.Layer.SegmentationLayer` (category="segmentation"),
         the parameter `largest_segment_id` also has to be specified.
 
-        The return type is `wkcuber.api.Layer`.
+        The return type is `wkcuber.api.Layer.Layer`.
 
         This function raises an `IndexError` if the specified `layer_name` already exists.
         """

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -186,7 +186,7 @@ class AbstractDataset(Generic[LayerT]):
 
     def get_layer(self, layer_name: str) -> LayerT:
         """
-        Returns the layer called `layer_name` of this dataset. The return type is `wkcuber.api.Layer`.
+        Returns the layer called `layer_name` of this dataset. The return type is `wkcuber.api.Layer.Layer.Layer`.
 
         This function raises an `IndexError` if the specified `layer_name` does not exist.
         """

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -1,8 +1,8 @@
 import operator
 from argparse import Namespace
 from shutil import rmtree
-from abc import ABC, abstractmethod
-from os import makedirs, path
+from abc import abstractmethod
+from os import makedirs
 from os.path import join, normpath, basename
 from pathlib import Path
 from typing import Type, Tuple, Union, Dict, Any, Optional, cast, TypeVar, Generic
@@ -17,7 +17,7 @@ from wkcuber.api.Properties.LayerProperties import (
 )
 from wkcuber.api.bounding_box import BoundingBox
 from wkcuber.mag import Mag
-from wkcuber.utils import logger, get_executor_for_args, ceil_div_np
+from wkcuber.utils import get_executor_for_args
 
 from wkcuber.api.Properties.DatasetProperties import (
     WKProperties,
@@ -63,9 +63,8 @@ def _normalize_dtype_per_channel(
         return np.dtype(dtype_per_channel)
     except TypeError as e:
         raise TypeError(
-            "Cannot add layer. The specified 'dtype_per_channel' must be a valid dtype. "
-            + str(e)
-        )
+            "Cannot add layer. The specified 'dtype_per_channel' must be a valid dtype."
+        ) from e
 
 
 def _normalize_dtype_per_layer(
@@ -89,9 +88,8 @@ def _dtype_per_layer_to_dtype_per_channel(
         )
     except TypeError as e:
         raise TypeError(
-            "Converting dtype_per_layer to dtype_per_channel failed. Double check if the dtype_per_layer value is correct. "
-            + str(e)
-        )
+            "Converting dtype_per_layer to dtype_per_channel failed. Double check if the dtype_per_layer value is correct."
+        ) from e
 
 
 def _dtype_per_channel_to_dtype_per_layer(
@@ -105,7 +103,7 @@ def _dtype_per_channel_to_dtype_per_layer(
 
 
 def _copy_job(args: Tuple[View, View, int]) -> None:
-    (source_view, target_view, i) = args
+    (source_view, target_view, _) = args
     # Copy the data form one view to the other in a buffered fashion
     target_view.write(source_view.read())
 
@@ -115,21 +113,33 @@ LayerT = TypeVar("LayerT", bound=Layer)
 
 class AbstractDataset(Generic[LayerT]):
     """
-    A dataset is the most high-level class of this API. Most of its functionality is implemented in the AbstractDataset,
-    which cannot be initiated. `WKDataset`, `TiffDataset` and `TiledTiffDataset` refine this class.
-
-    The dataset stores an `wkcuber.api.DatasetProperties` object and 
+    A dataset is the entry point of the Dataset API. An existing dataset on disk can be opened
+    or new datasets can be created.
     """
 
     @abstractmethod
     def __init__(self, dataset_path: Union[str, Path]) -> None:
-        dataset_path = Path(dataset_path)
-        properties: Properties = self._get_properties_type()._from_json(
-            dataset_path / Properties.FILE_NAME
+        """
+        To open an existing dataset on disk, simply call the constructor of the appropriate dataset type (e.g. `WKDataset`).
+        This requires that the `datasource-properties.json` exists. Based on the `datasource-properties.json`,
+        a dataset object is constructed. Only layers and magnifications that are listed in the properties are loaded
+        (even though there might exists more layer or magnifications on disk).
+
+        The `dataset_path` refers to the top level directory of the dataset (excluding layer or magnification names).
+        """
+
+        self.path = Path(dataset_path)
+        """Location of the dataset"""
+
+        self.properties: Properties = self._get_properties_type()._from_json(
+            self.path / Properties.FILE_NAME
         )
-        self.layers: Dict[str, LayerT] = {}
-        self.path = Path(properties.path).parent
-        self.properties = properties
+        """
+        The metadata from the `datasource-properties.json`. 
+        The properties are exported to disk automatically, every time the metadata changes.
+        """
+
+        self._layers: Dict[str, LayerT] = {}
         self._data_format = "abstract"
 
         # construct self.layer
@@ -142,7 +152,14 @@ class AbstractDataset(Generic[LayerT]):
                 num_channels=layer.num_channels,
             )
             for resolution in layer.wkw_magnifications:
-                self.layers[layer_name].setup_mag(resolution.mag.to_layer_name())
+                self.get_layer(layer_name)._setup_mag(resolution.mag.to_layer_name())
+
+    @property
+    def layers(self) -> Dict[str, LayerT]:
+        """
+        Getter for dictionary containing all layers.
+        """
+        return self._layers
 
     @classmethod
     def _create_with_properties(cls, properties: Properties) -> "AbstractDataset":
@@ -167,10 +184,12 @@ class AbstractDataset(Generic[LayerT]):
         # initialize object
         return cls(dataset_dir)
 
-    def get_properties(self) -> Properties:
-        return self.properties
-
     def get_layer(self, layer_name: str) -> LayerT:
+        """
+        Returns the layer called `layer_name` of this dataset. The return type is `wkcuber.api.Layer`.
+
+        This function raises an `IndexError` if the specified `layer_name` does not exist.
+        """
         if layer_name not in self.layers.keys():
             raise IndexError(
                 "The layer {} is not a layer of this dataset".format(layer_name)
@@ -186,6 +205,17 @@ class AbstractDataset(Generic[LayerT]):
         num_channels: int = None,
         **kwargs: Any,
     ) -> LayerT:
+        """
+        Creates a new layer called `layer_name` and adds it to the dataset.
+        The dtype can either be specified per layer or per channel.
+        If neither of them are specified, `uint8` per channel is used as default.
+        When creating a `wkcuber.api.Layer.SegmentationLayer` (category="segmentation"),
+        the parameter `largest_segment_id` also has to be specified.
+
+        The return type is `wkcuber.api.Layer`.
+
+        This function raises an `IndexError` if the specified `layer_name` already exists.
+        """
         if "dtype" in kwargs:
             raise ValueError(
                 f"Called Dataset.add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead."
@@ -232,7 +262,7 @@ class AbstractDataset(Generic[LayerT]):
             num_channels,
             **kwargs,
         )
-        self.layers[layer_name] = self._create_layer(
+        self._layers[layer_name] = self._create_layer(
             layer_name, dtype_per_channel, num_channels
         )
         return self.layers[layer_name]
@@ -246,6 +276,13 @@ class AbstractDataset(Generic[LayerT]):
         num_channels: int = None,
         **kwargs: Any,
     ) -> LayerT:
+        """
+        Creates a new layer called `layer_name` and adds it to the dataset, in case it did not exist before.
+        Then, returns the layer.
+
+        For more information see `add_layer`.
+        """
+
         if "dtype" in kwargs:
             raise ValueError(
                 f"Called Dataset.get_or_add_layer with 'dtype'={kwargs['dtype']}. This parameter is deprecated. Use 'dtype_per_layer' or 'dtype_per_channel' instead."
@@ -273,8 +310,8 @@ class AbstractDataset(Generic[LayerT]):
 
             if dtype_per_channel is not None or dtype_per_layer is not None:
                 dtype_per_channel = (
-                        dtype_per_channel
-                        or _dtype_per_layer_to_dtype_per_channel(
+                    dtype_per_channel
+                    or _dtype_per_layer_to_dtype_per_channel(
                         dtype_per_layer,
                         num_channels or self.layers[layer_name].num_channels,
                     )
@@ -299,16 +336,26 @@ class AbstractDataset(Generic[LayerT]):
             )
 
     def delete_layer(self, layer_name: str) -> None:
+        """
+        Deletes the layer from the `datasource-properties.json` and the data from disk.
+        """
+
         if layer_name not in self.layers.keys():
             raise IndexError(
                 f"Removing layer {layer_name} failed. There is no layer with this name"
             )
-        del self.layers[layer_name]
+        del self._layers[layer_name]
         self.properties._delete_layer(layer_name)
         # delete files on disk
         rmtree(join(self.path, layer_name))
 
     def add_symlink_layer(self, foreign_layer_path: Union[str, Path]) -> LayerT:
+        """
+        Creates a symlink to the data at `foreign_layer_path` which belongs to another dataset.
+        The relevant information from the `datasource-properties.json` of the other dataset is copied to this dataset.
+        Note: If the other dataset modifies its bounding box afterwards, the change does not affect this properties
+        (or vice versa).
+        """
         foreign_layer_path = Path(os.path.abspath(foreign_layer_path))
         layer_name = foreign_layer_path.name
         if layer_name in self.layers.keys():
@@ -325,7 +372,7 @@ class AbstractDataset(Generic[LayerT]):
         self.properties.data_layers[layer_name] = layer_properties
         self.properties._export_as_json()
 
-        self.layers[layer_name] = self._create_layer(
+        self._layers[layer_name] = self._create_layer(
             layer_name,
             _dtype_per_layer_to_dtype_per_channel(
                 layer_properties.element_class, layer_properties.num_channels
@@ -333,7 +380,7 @@ class AbstractDataset(Generic[LayerT]):
             layer_properties.num_channels,
         )
         for resolution in layer_properties.wkw_magnifications:
-            self.layers[layer_name].setup_mag(resolution.mag.to_layer_name())
+            self.get_layer(layer_name)._setup_mag(resolution.mag.to_layer_name())
         return self.layers[layer_name]
 
     def get_view(
@@ -345,6 +392,12 @@ class AbstractDataset(Generic[LayerT]):
         is_bounded: bool = True,
         read_only: bool = False,
     ) -> View:
+        """
+        Returns a view of the specified `wkcuber.api.MagDataset.MagDataset`.
+        This is a shorthand for `dataset.get_layer(layer_name).get_mag(mag).get_view(...)`
+
+        See `wkcuber.api.MagDataset.get_view` for more details.
+        """
         layer = self.get_layer(layer_name)
         mag_ds = layer.get_mag(mag)
 
@@ -360,9 +413,14 @@ class AbstractDataset(Generic[LayerT]):
     def copy_dataset(
         self, empty_target_ds: "AbstractDataset", args: Optional[Namespace] = None
     ) -> None:
+        """
+        Copies the data from the current dataset to `empty_target_ds`. The types of the two datasets can differ
+        (e.g. on dataset can be `WKDataset` and the other can be `TiffDataset`).
+        Therefore, this method can be used to convert from one type to the other.
+        """
         assert (
             len(empty_target_ds.layers) == 0
-        ), f"Copying dataset failed. The target dataset must be empty."
+        ), "Copying dataset failed. The target dataset must be empty."
         with get_executor_for_args(args) as executor:
             for layer_name, layer in self.layers.items():
                 largest_segment_id = None
@@ -418,6 +476,11 @@ class AbstractDataset(Generic[LayerT]):
         new_dataset_path: Union[str, Path],
         scale: Optional[Tuple[float, float, float]] = None,
     ) -> "WKDataset":
+        """
+        Creates a new `WKDataset` at `new_dataset_path` and copies the data from this dataset to the new dataset.
+
+        This is a shorthand for creating an empty `WKDataset` and then calling `AbstractDataset.copy_dataset`
+        """
         new_dataset_path = Path(new_dataset_path)
         if scale is None:
             scale = self.properties.scale
@@ -431,6 +494,11 @@ class AbstractDataset(Generic[LayerT]):
         scale: Optional[Tuple[float, float, float]] = None,
         pattern: Optional[str] = None,
     ) -> "TiffDataset":
+        """
+        Creates a new `TiffDataset` at `new_dataset_path` and copies the data from this dataset to the new dataset.
+
+        This is a shorthand for creating an empty `TiffDataset` and then calling `AbstractDataset.copy_dataset`
+        """
         new_dataset_path = Path(new_dataset_path)
         if scale is None:
             scale = self.properties.scale
@@ -445,6 +513,11 @@ class AbstractDataset(Generic[LayerT]):
         scale: Optional[Tuple[float, float, float]] = None,
         pattern: Optional[str] = None,
     ) -> "TiledTiffDataset":
+        """
+        Creates a new `TiledTiffDataset` at `new_dataset_path` and copies the data from this dataset to the new dataset.
+
+        This is a shorthand for creating an empty `TiledTiffDataset` and then calling `AbstractDataset.copy_dataset`
+        """
         new_dataset_path = Path(new_dataset_path)
         if scale is None:
             scale = self.properties.scale
@@ -464,10 +537,20 @@ class AbstractDataset(Generic[LayerT]):
 
 
 class WKDataset(AbstractDataset[WKLayer]):
+    """
+    A dataset is the entry point of the Dataset API. An existing dataset on disk can be opened
+    or new datasets can be created.
+
+    A `WKDataset` stores the data in `.wkw` files on disk.
+    """
+
     @classmethod
     def create(
         cls, dataset_path: Union[str, Path], scale: Tuple[float, float, float]
     ) -> "WKDataset":
+        """
+        Creates a new dataset and the associated `datasource-properties.json`.
+        """
         dataset_path = Path(dataset_path)
         name = basename(normpath(dataset_path))
         properties = WKProperties(dataset_path / Properties.FILE_NAME, name, scale)
@@ -477,6 +560,10 @@ class WKDataset(AbstractDataset[WKLayer]):
     def get_or_create(
         cls, dataset_path: Union[str, Path], scale: Tuple[float, float, float]
     ) -> "WKDataset":
+        """
+        Creates a new `WKDataset`, in case it did not exist before, and then returns it.
+        The `datasource-properties.json` is used to check if the dataset already exist.
+        """
         dataset_path = Path(dataset_path)
         if (
             dataset_path / Properties.FILE_NAME
@@ -507,6 +594,13 @@ class WKDataset(AbstractDataset[WKLayer]):
 
 
 class TiffDataset(AbstractDataset[TiffLayer]):
+    """
+    A dataset is the entry point of the Dataset API. An existing dataset on disk can be opened
+    or new datasets can be created.
+
+    A `TiffDataset` stores the data in tiff-files on disk. Each z-slice is stored in a separate tiff-image.
+    """
+
     properties: TiffProperties
 
     @classmethod
@@ -516,6 +610,11 @@ class TiffDataset(AbstractDataset[TiffLayer]):
         scale: Tuple[float, float, float],
         pattern: Optional[str] = None,
     ) -> "TiffDataset":
+        """
+        Creates a new dataset and the associated `datasource-properties.json`.
+        The `pattern` defines the format of the file structure / filename of the files on disk.
+        The default pattern is `"{zzzzz}.tif"`.
+        """
         dataset_path = Path(dataset_path)
         if pattern is None:
             pattern = "{zzzzz}.tif"
@@ -537,6 +636,12 @@ class TiffDataset(AbstractDataset[TiffLayer]):
         scale: Tuple[float, float, float],
         pattern: str = None,
     ) -> "TiffDataset":
+        """
+        Creates a new `TiffDataset`, in case it did not exist before, and then returns it.
+        The `datasource-properties.json` is used to check if the dataset already exist.
+
+        See `TiffDataset.create` for more information.
+        """
         dataset_path = Path(dataset_path)
         if (dataset_path / Properties.FILE_NAME).exists():
             # use the properties file to check if the Dataset exists
@@ -573,6 +678,14 @@ class TiffDataset(AbstractDataset[TiffLayer]):
 
 
 class TiledTiffDataset(AbstractDataset[TiledTiffLayer]):
+    """
+    A dataset is the entry point of the Dataset API. An existing dataset on disk can be opened
+    or new datasets can be created.
+
+    A `TiledTiffDataset` stores the data in tiff-files on disk.
+    Each z-slice is composed into multiple smaller tiff-image.
+    """
+
     properties: TiffProperties
 
     @classmethod
@@ -583,6 +696,12 @@ class TiledTiffDataset(AbstractDataset[TiledTiffLayer]):
         tile_size: Tuple[int, int],
         pattern: Optional[str] = None,
     ) -> "TiledTiffDataset":
+        """
+        Creates a new dataset and the associated `datasource-properties.json`.
+        The `pattern` defines the format of the file structure / filename of the files on disk.
+        The default pattern is `"{xxxxx}/{yyyyy}/{zzzzz}.tif"`.
+        The `tile_size` specifies the dimensions of a single tiff-tile.
+        """
         dataset_path = Path(dataset_path)
         if pattern is None:
             pattern = "{xxxxx}/{yyyyy}/{zzzzz}.tif"
@@ -607,6 +726,12 @@ class TiledTiffDataset(AbstractDataset[TiledTiffLayer]):
         tile_size: Tuple[int, int],
         pattern: str = None,
     ) -> "TiledTiffDataset":
+        """
+        Creates a new `TiledTiffDataset`, in case it did not exist before, and then returns it.
+        The `datasource-properties.json` is used to check if the dataset already exist.
+
+        See `TiledTiffDataset.create` for more information.
+        """
         dataset_path = Path(dataset_path)
         if (dataset_path / Properties.FILE_NAME).exists():
             # use the properties file to check if the Dataset exists

--- a/wkcuber/api/Dataset.py
+++ b/wkcuber/api/Dataset.py
@@ -186,7 +186,7 @@ class AbstractDataset(Generic[LayerT]):
 
     def get_layer(self, layer_name: str) -> LayerT:
         """
-        Returns the layer called `layer_name` of this dataset. The return type is `wkcuber.api.Layer.Layer.Layer`.
+        Returns the layer called `layer_name` of this dataset. The return type is `wkcuber.api.Layer.Layer`.
 
         This function raises an `IndexError` if the specified `layer_name` does not exist.
         """

--- a/wkcuber/api/Layer.py
+++ b/wkcuber/api/Layer.py
@@ -77,7 +77,7 @@ class Layer(Generic[MagT]):
         num_channels: int,
     ) -> None:
         """
-        Creates the folder `name` in the directory if the `dataset`.
+        Creates the folder `name` in the directory of `dataset`.
 
         A `Layer` cannot exist without a dataset. The desired procedure to create a new layer for a dataset is to call
         `wkcuber.api.Dataset.AbstractDataset.add_layer` instead of creating and then adding it manually.

--- a/wkcuber/api/Layer.py
+++ b/wkcuber/api/Layer.py
@@ -205,7 +205,7 @@ class Layer(Generic[MagT]):
     def _initialize_mag_from_other_mag(
         self, new_mag_name: Union[str, Mag], other_mag: MagDataset, compress: bool
     ) -> MagDataset:
-        raise NotImplemented
+        raise NotImplementedError
 
     def downsample(
         self,
@@ -695,7 +695,7 @@ class TiledTiffLayer(_GenericTiffLayer[TiledTiffMagDataset]):
         """
         Downsampling is currently not supported for TiledTiffLayers. Use `wkcuber.api.Dataset.TiffDataset`s (which has `TiffLayer`s) instead.
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def downsample_mag(
         self,
@@ -709,7 +709,7 @@ class TiledTiffLayer(_GenericTiffLayer[TiledTiffMagDataset]):
         """
         Downsampling is currently not supported for TiledTiffLayers. Use `wkcuber.api.Dataset.TiffDataset`s (which has `TiffLayer`s) instead.
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def downsample_mag_list(
         self,
@@ -723,4 +723,4 @@ class TiledTiffLayer(_GenericTiffLayer[TiledTiffMagDataset]):
         """
         Downsampling is currently not supported for TiledTiffLayers. Use `wkcuber.api.Dataset.TiffDataset`s (which has `TiffLayer`s) instead.
         """
-        raise NotImplemented
+        raise NotImplementedError

--- a/wkcuber/api/Properties/DatasetProperties.py
+++ b/wkcuber/api/Properties/DatasetProperties.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Union, Tuple, Optional, Dict, Any, cast
+from typing import Tuple, Optional, Dict, Any, cast
 
 from wkcuber.api.Layer import Layer
 from wkcuber.api.Properties.LayerProperties import (
@@ -9,7 +9,6 @@ from wkcuber.api.Properties.LayerProperties import (
 )
 from wkcuber.api.Properties.ResolutionProperties import WkResolution, Resolution
 from wkcuber.mag import Mag
-import numpy as np
 
 
 class Properties:

--- a/wkcuber/api/Properties/LayerProperties.py
+++ b/wkcuber/api/Properties/LayerProperties.py
@@ -10,7 +10,7 @@ from wkcuber.mag import Mag
 from wkcuber.api.bounding_box import BoundingBox
 
 
-def extract_num_channels(
+def _extract_num_channels(
     num_channels_in_properties: Optional[int],
     path: Path,
     layer: str,
@@ -124,7 +124,7 @@ class LayerProperties:
                 json_data["elementClass"], json_data["elementClass"]
             ),
             json_data["dataFormat"],
-            extract_num_channels(
+            _extract_num_channels(
                 json_data.get("num_channels"),
                 dataset_path,
                 json_data["name"],
@@ -263,7 +263,7 @@ class SegmentationLayerProperties(LayerProperties):
                 json_data["elementClass"], json_data["elementClass"]
             ),
             json_data["dataFormat"],
-            extract_num_channels(
+            _extract_num_channels(
                 json_data.get("num_channels"),
                 dataset_path,
                 json_data["name"],

--- a/wkcuber/api/View.py
+++ b/wkcuber/api/View.py
@@ -289,7 +289,7 @@ class View:
         return absolute_offset, data
 
     def get_dtype(self) -> type:
-        raise NotImplemented
+        raise NotImplementedError
 
     def __enter__(self) -> "View":
         return self
@@ -363,9 +363,8 @@ class WKView(View):
                 aligned_data = self.read(offset=aligned_offset, size=aligned_shape)
             except AssertionError as e:
                 raise AssertionError(
-                    f"Writing compressed data failed. The compressed file is not fully inside the bounding box of the view (offset={self.global_offset}, size={self.size}). "
-                    + str(e)
-                )
+                    f"Writing compressed data failed. The compressed file is not fully inside the bounding box of the view (offset={self.global_offset}, size={self.size})."
+                ) from e
             index_slice = (
                 slice(None, None),
                 *(

--- a/wkcuber/api/View.py
+++ b/wkcuber/api/View.py
@@ -1,8 +1,7 @@
 import math
-from concurrent.futures._base import Executor
 from pathlib import Path
 from types import TracebackType
-from typing import Tuple, Optional, Type, Callable, Any, Union, List, cast
+from typing import Tuple, Optional, Type, Callable, Union, cast
 
 import cluster_tools
 import numpy as np
@@ -51,7 +50,7 @@ class View:
         relative_offset: Tuple[int, int, int] = (0, 0, 0),
         allow_compressed_write: bool = False,
     ) -> None:
-        assert not self.read_only, f"Cannot write data to an read_only View"
+        assert not self.read_only, "Cannot write data to an read_only View"
 
         was_opened = self._is_opened
         # assert the size of the parameter data is not in conflict with the attribute self.size
@@ -115,12 +114,12 @@ class View:
             is_bounded = self.is_bounded
         assert (
             is_bounded or is_bounded == self.is_bounded
-        ), f"Failed to get subview. The calling view is bounded. Therefore, the subview also has to be bounded."
+        ), "Failed to get subview. The calling view is bounded. Therefore, the subview also has to be bounded."
         if read_only is None:
             read_only = self.read_only
         assert (
             read_only or read_only == self.read_only
-        ), f"Failed to get subview. The calling view is read_only. Therefore, the subview also has to be read_only."
+        ), "Failed to get subview. The calling view is read_only. Therefore, the subview also has to be read_only."
         self.assert_bounds(relative_offset, size)
         view_offset = cast(
             Tuple[int, int, int], tuple(self.global_offset + np.array(relative_offset))
@@ -212,10 +211,10 @@ class View:
         target_chunk_size_np = np.array(target_chunk_size)
         assert np.all(
             np.array(self.size)
-        ), f"Calling 'for_zipped_chunks' failed because the size of the source view contains a 0."
+        ), "Calling 'for_zipped_chunks' failed because the size of the source view contains a 0."
         assert np.all(
             np.array(target_view.size)
-        ), f"Calling 'for_zipped_chunks' failed because the size of the target view contains a 0."
+        ), "Calling 'for_zipped_chunks' failed because the size of the target view contains a 0."
         assert np.array_equal(
             np.array(self.size) / np.array(target_view.size),
             source_chunk_size_np / target_chunk_size_np,
@@ -236,7 +235,7 @@ class View:
                     )
                     - (target_offset[:2] // target_chunk_size[:2]),
                     [1, 1],
-                ), f"Calling for_zipped_chunks failed. There can only be a single chunk per z-slice for TiffDatasets. Choose a different 'target_chunk_size'."
+                ), "Calling for_zipped_chunks failed. There can only be a single chunk per z-slice for TiffDatasets. Choose a different 'target_chunk_size'."
             else:
                 # TiledTiffDataset
                 assert not any(

--- a/wkcuber/api/__init__.py
+++ b/wkcuber/api/__init__.py
@@ -1,16 +1,17 @@
 """
 # High Level Dataset API
 
-The high level Dataset API is ...
+The high level Dataset API is a set of classes that encapsulate the main functionalities for interacting with a dataset.
+The aim is to make the experience for the user easy as possible, by automatically reading important meta information
+from the `datasource-properties.json` for any dataset and updating this file if necessary.
 
+A dataset is the most high-level class of this API.
 There are three types of datasets:
 - `wkcuber.api.Dataset.WKDataset`
 - `wkcuber.api.Dataset.TiffDataset`
 - `wkcuber.api.Dataset.TiledTiffDataset`
 
+Each of these datasets derives from `wkcuber.api.Dataset.WKDataset.AbstractDataset`, which implements most of the functionality.
 The datasets differ in the way they store the data on disc.
 In practice, most of the time `wkcuber.api.Dataset.WKDataset` is used because wkw-files are our go-to file format.
-
-`wkcuber.api.Dataset.WKDataset`
-.. include:: ../../README.md
 """

--- a/wkcuber/api/__init__.py
+++ b/wkcuber/api/__init__.py
@@ -1,17 +1,14 @@
 """
-# High Level Dataset API
+# Dataset API
 
-The high level Dataset API is a set of classes that encapsulate the main functionalities for interacting with a dataset.
-The aim is to make the experience for the user easy as possible, by automatically reading important meta information
-from the `datasource-properties.json` for any dataset and updating this file if necessary.
+The high-level dataset API automatically reads and writes meta information for any dataset and updates them if necessary, such as the `datasource-properties.json`.
 
-A dataset is the most high-level class of this API.
-There are three types of datasets:
-- `wkcuber.api.Dataset.WKDataset`
+A dataset is the entry-point for this API. All datasets are subclassing the abstract `wkcuber.api.Dataset.AbstractDataset` class, which implements most of the functionality.
+
+The following concrete implementations are available, differing in the way they store the data on disk:
+- `wkcuber.api.Dataset.WKDataset` (for [webknossos-wrap (wkw)](https://github.com/scalableminds/webknossos-wrap) datasets)
 - `wkcuber.api.Dataset.TiffDataset`
 - `wkcuber.api.Dataset.TiledTiffDataset`
 
-Each of these datasets derives from `wkcuber.api.Dataset.WKDataset.AbstractDataset`, which implements most of the functionality.
-The datasets differ in the way they store the data on disc.
-In practice, most of the time `wkcuber.api.Dataset.WKDataset` is used because wkw-files are our go-to file format.
+Each dataset consists of one or more layers (wkcuber.api.Layer.Layer), which themselves can comprise multiple magnifications (wkcuber.api.MagDataset.MagDataset).
 """

--- a/wkcuber/api/__init__.py
+++ b/wkcuber/api/__init__.py
@@ -1,0 +1,16 @@
+"""
+# High Level Dataset API
+
+The high level Dataset API is ...
+
+There are three types of datasets:
+- `wkcuber.api.Dataset.WKDataset`
+- `wkcuber.api.Dataset.TiffDataset`
+- `wkcuber.api.Dataset.TiledTiffDataset`
+
+The datasets differ in the way they store the data on disc.
+In practice, most of the time `wkcuber.api.Dataset.WKDataset` is used because wkw-files are our go-to file format.
+
+`wkcuber.api.Dataset.WKDataset`
+.. include:: ../../README.md
+"""

--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -114,7 +114,11 @@ class BoundingBox:
 
     def as_wkw(self) -> dict:
 
-        width, height, depth = self.size.tolist()
+        (
+            width,
+            height,
+            depth,
+        ) = self.size.tolist()  # pylint: disable=unbalanced-tuple-unpacking
 
         return {
             "topLeft": self.topleft.tolist(),

--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -114,11 +114,11 @@ class BoundingBox:
 
     def as_wkw(self) -> dict:
 
-        (
+        (  # pylint: disable=unbalanced-tuple-unpacking
             width,
             height,
             depth,
-        ) = self.size.tolist()  # pylint: disable=unbalanced-tuple-unpacking
+        ) = self.size.tolist()
 
         return {
             "topLeft": self.topleft.tolist(),

--- a/wkcuber/check_equality.py
+++ b/wkcuber/check_equality.py
@@ -66,7 +66,7 @@ def assert_equality_for_chunk(
     sub_box: BoundingBoxNamedTuple,
 ) -> None:
     wk_dataset = WKDataset(source_path)
-    layer = wk_dataset.layers[layer_name]
+    layer = wk_dataset.get_layer(layer_name)
     backup_wkw_info = WkwDatasetInfo(target_path, layer_name, mag, header=None)
     with open_wkw(backup_wkw_info) as backup_wkw:
         mag_ds = layer.get_mag(mag)


### PR DESCRIPTION
### Description:
- `pdoc` is used to create the documentation. Running `docs/api.sh` opens the documentation in the browser.
- The documentation is currently limited to the Dataset API
 
### Issues:
- fixes #302 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
