### PR TITLE
Conversion from BoundingBox to BoundingBoxNamedTuple

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
+- Added a function for converting `BoundingBox` to `BoundingBoxNamedTuple`. [#324](https://github.com/scalableminds/webknossos-cuber/pull/324)
 
 ### Changed
 

--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -143,6 +143,12 @@ class BoundingBox:
 
         return ",".join(map(str, self.as_tuple6()))
 
+    def as_named_tuple(self) -> BoundingBoxNamedTuple:
+        return BoundingBoxNamedTuple(
+            topleft=cast(Tuple[int, int, int], tuple(self.topleft)),
+            size=cast(Tuple[int, int, int], tuple(self.size)),
+        )
+
     def __repr__(self) -> str:
 
         return "BoundingBox(topleft={}, size={})".format(


### PR DESCRIPTION
### Description:
- Previously there was only a function to convert a `BoundingBoxNamedTuple` to a `BoundingBox` (`from_named_tuple`)
- This PR adds a function to convert a `BoundingBox` to a `BoundingBoxNamedTuple` (`as_named_tuple`)

### Issues:
- fixes #321 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
