### PR TITLE
Fix compressed write

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,18 @@ and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MIC
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.6...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.7...HEAD)
+
+### Breaking Changes in Config & CLI
+
+### Added
+
+### Changed
+
+### Fixed
+
+## [0.6.7](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.7) - 2021-05-28
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.6...v0.6.7)
 
 ### Breaking Changes in Config & CLI
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Fixed a bug for writing compressed data. This previously caused an error when downsampling certain datasets. [#326](https://github.com/scalableminds/webknossos-cuber/pull/326)
 
 ## [0.6.6](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.6) - 2021-05-14
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.5...v0.6.6)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2050,11 +2050,16 @@ def test_compression() -> None:
 
     # writing unaligned data to an uncompressed dataset
     write_data = (np.random.rand(3, 10, 20, 30) * 255).astype(np.uint8)
-    mag1.write(write_data)
+
+    # Writing compressed data directly to "mag1" also works, but using a View here covers an additional edge case
+    view = mag1.get_view(offset=(50, 60, 70), is_bounded=False)
+    view.write(write_data, relative_offset=(10, 20, 30))
 
     mag1.compress()
 
-    assert np.array_equal(write_data, mag1.read(size=(10, 20, 30)))
+    assert np.array_equal(
+        write_data, mag1.read(offset=(60, 80, 100), size=(10, 20, 30))
+    )
 
     with pytest.raises(wkw.WKWException):
         # writing unaligned data to a compressed dataset

--- a/wkcuber/api/View.py
+++ b/wkcuber/api/View.py
@@ -140,6 +140,8 @@ class View:
         for s1, s2, off in zip(self.size, size, offset):
             if s2 + off > s1 and self.is_bounded:
                 return False
+        if self.is_bounded and any(x < 0 for x in offset):
+            return False
         return True
 
     def assert_bounds(
@@ -210,6 +212,7 @@ class View:
         target_offset = np.array(target_view.global_offset)
         source_chunk_size_np = np.array(source_chunk_size)
         target_chunk_size_np = np.array(target_chunk_size)
+
         assert np.all(
             np.array(self.size)
         ), f"Calling 'for_zipped_chunks' failed because the size of the source view contains a 0."
@@ -361,7 +364,12 @@ class WKView(View):
             # the data is not aligned
             # read the aligned bounding box
             try:
-                aligned_data = self.read(offset=aligned_offset, size=aligned_shape)
+                # The absolute offset might be outside of the current view.
+                # We want to read the data at the absolute offset.
+                # However, this view has its own global_offset (which might or might not be equal to (0, 0, 0))
+                # The parameter `offset` of the read-function of a View is always relative (unlike MagDataset.read where the offset is absolute)
+                # Therefore, we need to calculate the relative offset
+                aligned_data = self.read(offset=aligned_offset-self.global_offset, size=aligned_shape)
             except AssertionError as e:
                 raise AssertionError(
                     f"Writing compressed data failed. The compressed file is not fully inside the bounding box of the view (offset={self.global_offset}, size={self.size}). "

--- a/wkcuber/api/View.py
+++ b/wkcuber/api/View.py
@@ -369,7 +369,9 @@ class WKView(View):
                 # However, this view has its own global_offset (which might or might not be equal to (0, 0, 0))
                 # The parameter `offset` of the read-function of a View is always relative (unlike MagDataset.read where the offset is absolute)
                 # Therefore, we need to calculate the relative offset
-                aligned_data = self.read(offset=aligned_offset-self.global_offset, size=aligned_shape)
+                aligned_data = self.read(
+                    offset=aligned_offset - self.global_offset, size=aligned_shape
+                )
             except AssertionError as e:
                 raise AssertionError(
                     f"Writing compressed data failed. The compressed file is not fully inside the bounding box of the view (offset={self.global_offset}, size={self.size}). "

--- a/wkcuber/api/View.py
+++ b/wkcuber/api/View.py
@@ -55,7 +55,6 @@ class View:
 
         was_opened = self._is_opened
         # assert the size of the parameter data is not in conflict with the attribute self.size
-        assert_non_negative_offset(relative_offset)
         self.assert_bounds(relative_offset, data.shape[-3:])
 
         if len(data.shape) == 4 and data.shape[0] == 1:
@@ -374,9 +373,8 @@ class WKView(View):
                 )
             except AssertionError as e:
                 raise AssertionError(
-                    f"Writing compressed data failed. The compressed file is not fully inside the bounding box of the view (offset={self.global_offset}, size={self.size}). "
-                    + str(e)
-                )
+                    f"Reading compressed data failed. The compressed file is not fully inside the bounding box of the view (offset={self.global_offset}, size={self.size})."
+                ) from e
             index_slice = (
                 slice(None, None),
                 *(
@@ -431,13 +429,3 @@ class TiffView(View):
 
     def get_dtype(self) -> type:
         return self.header.dtype_per_channel
-
-
-def assert_non_negative_offset(offset: Tuple[int, int, int]) -> None:
-    all_positive = all(i >= 0 for i in offset)
-    if not all_positive:
-        raise Exception(
-            "All elements of the offset need to be positive: %s" % "("
-            + ",".join(map(str, offset))
-            + ")"
-        )


### PR DESCRIPTION
### Description:
- Downsampling of compressed datasets failed. The cause was a bug in the the way compressed data was written
- `_handle_compressed_write` passed an absolute offset to `read`, which expected a relative offset. This is now fixed.


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
