### PR TITLE
Fix BoundinBox.copy()

### DIFF
--- a/wkcuber/api/bounding_box.py
+++ b/wkcuber/api/bounding_box.py
@@ -318,7 +318,7 @@ class BoundingBox:
 
     def copy(self) -> "BoundingBox":
 
-        return BoundingBox(self.topleft.copy(), self.bottomright.copy())
+        return BoundingBox(self.topleft.copy(), self.size.copy())
 
     def offset(self, vector: Tuple[int, int, int]) -> "BoundingBox":
 


### PR DESCRIPTION
### Description:
Fixes a bug in `BoundingBox.copy()`.

Before:
```
>>> BoundingBox(topleft=(3072, 3072, 512), size=(1024, 1024, 1024)).copy()
BoundingBox(topleft=(3072, 3072, 512), size=(4096, 4096, 1536))
```