### PR TITLE
Fix regexes that assume unix-paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,19 @@ and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MIC
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.7...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.8...HEAD)
+
+### Breaking Changes in Config & CLI
+
+### Added
+
+### Changed
+
+### Fixed
+- Use an os independent path separator for regexes. [#334](https://github.com/scalableminds/webknossos-cuber/pull/334)
+
+## [0.6.8](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.8) - 2021-06-18
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.7...v0.6.8)
 
 ### Breaking Changes in Config & CLI
 
@@ -17,6 +29,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+
 
 ## [0.6.7](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.6.7) - 2021-05-28
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.6.6...v0.6.7)

--- a/wkcuber/knossos.py
+++ b/wkcuber/knossos.py
@@ -11,7 +11,9 @@ from glob import iglob, glob
 CUBE_EDGE_LEN = 128
 CUBE_SIZE = CUBE_EDGE_LEN ** 3
 CUBE_SHAPE = (CUBE_EDGE_LEN,) * 3
-CUBE_REGEX = re.compile(r"x(\d+)/y(\d+)/z(\d+)/(.*\.raw)$")
+CUBE_REGEX = re.compile(
+    fr"x(\d+){os.path.sep}y(\d+){os.path.sep}z(\d+){os.path.sep}(.*\.raw)$"
+)
 
 
 class KnossosDataset:

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import wkw
 import logging
@@ -235,7 +236,9 @@ def detect_bbox(dataset_path: Path, layer: str, mag: Mag = Mag(1)) -> Optional[d
         return iglob(path.join(layer_path, "*", "*", "*.wkw"), recursive=True)
 
     def parse_cube_file_name(filename: str) -> Tuple[int, int, int]:
-        CUBE_REGEX = re.compile(r"z(\d+)/y(\d+)/x(\d+)(\.wkw)$")
+        CUBE_REGEX = re.compile(
+            fr"z(\d+){os.path.sep}y(\d+){os.path.sep}x(\d+)(\.wkw)$"
+        )
         m = CUBE_REGEX.search(filename)
         if m is not None:
             return int(m.group(3)), int(m.group(2)), int(m.group(1))

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -49,7 +49,7 @@ FallbackArgs = namedtuple("FallbackArgs", ("distribution_strategy", "jobs"))
 BLOCK_LEN = 32
 DEFAULT_WKW_FILE_LEN = 32
 DEFAULT_WKW_VOXELS_PER_BLOCK = 32
-CUBE_REGEX = re.compile(r"z(\d+)/y(\d+)/x(\d+)(\.wkw)$")
+CUBE_REGEX = re.compile(fr"z(\d+){os.path.sep}y(\d+){os.path.sep}x(\d+)(\.wkw)$")
 
 logger = getLogger(__name__)
 


### PR DESCRIPTION
### Description:
- Previously "/" was hard coded in some regexes. This is now replaces with `os.path.sep`, which is os independent.

### Issues:
- fixes #253 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
