### PR TITLE
Add method to Dataset API to copy an existing layer from a different dataset

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
+- Added `add_copy_layer()` to `wkcuber.api.dataset.Dataset` to copy the layer of a different dataset. [#345](https://github.com/scalableminds/webknossos-cuber/pull/345)
 
 ### Changed
 


### PR DESCRIPTION
### Description:
- Add method to Dataset API to copy an existing layer from a different dataset

### Issues:
- fixes #343 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
