### PR TITLE
Dataset api read at a specific bounding box

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,12 +12,23 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
-- Added `add_copy_layer()` to `wkcuber.api.dataset.Dataset` to copy the layer of a different dataset. [#345](https://github.com/scalableminds/webknossos-cuber/pull/345)
 
 ### Changed
 
 ### Fixed
 
+## [0.8.1](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.1) - 2021-07-22
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.0...v0.8.1)
+
+### Breaking Changes in Config & CLI
+
+### Added
+- Added `add_copy_layer()` to `wkcuber.api.dataset.Dataset` to copy the layer of a different dataset. [#345](https://github.com/scalableminds/webknossos-cuber/pull/345)
+- Added `View.read_bbox()` which takes only a single bounding box as parameter (instead of an offset and size). [#347](https://github.com/scalableminds/webknossos-cuber/pull/347)
+
+### Changed
+
+### Fixed
 
 ## [0.8.0](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.0) - 2021-07-16
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.7.0...v0.8.0)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -14,6 +14,7 @@ from shutil import rmtree, copytree
 from wkw import wkw
 from wkw.wkw import WKWException
 
+from wkcuber.api.bounding_box import BoundingBox
 from wkcuber.api.dataset import Dataset
 from os import makedirs
 
@@ -1439,3 +1440,16 @@ def test_dataset_name(tmp_path: Path) -> None:
         tmp_path / "some_new_name", scale=(1, 1, 1), name="very important dataset"
     )
     assert ds2.name == "very important dataset"
+
+
+def test_read_bbox(tmp_path: Path):
+    ds = Dataset.create(tmp_path, scale=(2,2,1))
+    layer = ds.add_layer("color", LayerCategories.COLOR_TYPE)
+    mag = layer.add_mag(1)
+    mag.write(offset=(10, 20, 30), data=(np.random.rand(50, 60, 70) * 255).astype(np.uint8))
+
+    assert np.array_equal(mag.read(), mag.read_bbox())
+    assert np.array_equal(
+        mag.read(offset=(20, 30, 40), size=(40, 50, 60)),
+        mag.read_bbox(BoundingBox(topleft=(20, 30, 40), size=(40, 50, 60)))
+    )

--- a/wkcuber/api/view.py
+++ b/wkcuber/api/view.py
@@ -163,6 +163,16 @@ class View:
             cast(Tuple[int, int, int], absolute_offset), size
         )
 
+    def read_bbox(self, bounding_box: Optional[BoundingBox] = None) -> np.array:
+        """
+        The user can specify the `bounding_box` of the requested data.
+        See `read()` for more details.
+        """
+        if bounding_box is None:
+            return self.read()
+        else:
+            return self.read(bounding_box.topleft, bounding_box.size)
+
     def _read_without_checks(
         self,
         absolute_offset: Tuple[int, int, int],


### PR DESCRIPTION
### Description:
- `View.read()` has the parameters `offset` and `size`. However, often it is easier to pass a bounding box. Therefore, the method `read_bbox()` was added.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
