### PR TITLE
Remove the parameter allow_compressed_write by always allowing it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.0...HEAD)
 
 ### Breaking Changes in Config & CLI
+- The parameter allow_compressed_write from View.write() is now removed. Writing to compressed magnifications is now always allowed. If the user decides to write unaligned data, a warning about a possible performance impact is displayed once. [#356](https://github.com/scalableminds/webknossos-cuber/pull/356)
 
 ### Added
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,12 +12,23 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
-- Added `add_copy_layer()` to `wkcuber.api.dataset.Dataset` to copy the layer of a different dataset. [#345](https://github.com/scalableminds/webknossos-cuber/pull/345)
 
 ### Changed
 
 ### Fixed
 
+## [0.8.1](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.1) - 2021-07-22
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.0...v0.8.1)
+
+### Breaking Changes in Config & CLI
+
+### Added
+- Added `add_copy_layer()` to `wkcuber.api.dataset.Dataset` to copy the layer of a different dataset. [#345](https://github.com/scalableminds/webknossos-cuber/pull/345)
+- Added `View.read_bbox()` which takes only a single bounding box as parameter (instead of an offset and size). [#347](https://github.com/scalableminds/webknossos-cuber/pull/347)
+
+### Changed
+
+### Fixed
 
 ## [0.8.0](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.0) - 2021-07-16
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.7.0...v0.8.0)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1032,7 +1032,6 @@ def test_writing_subset_of_compressed_data() -> None:
         Dataset(TESTOUTPUT_DIR / "compressed_data").get_layer("color").get_mag("1")
     )
 
-    # Calling 'write' with unaligned data on compressed data only fails if the warnings are treated as errors.
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore", category=RuntimeWarning, module="wkcuber"
@@ -1043,6 +1042,7 @@ def test_writing_subset_of_compressed_data() -> None:
         )
 
     with warnings.catch_warnings():
+        # Calling 'write' with unaligned data on compressed data only fails if the warnings are treated as errors.
         warnings.filterwarnings("error")  # This escalates the warning to an error
         with pytest.raises(RuntimeWarning):
             compressed_mag.write(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1442,6 +1442,21 @@ def test_dataset_name(tmp_path: Path) -> None:
     assert ds2.name == "very important dataset"
 
 
+def test_read_bbox(tmp_path: Path) -> None:
+    ds = Dataset.create(tmp_path, scale=(2, 2, 1))
+    layer = ds.add_layer("color", LayerCategories.COLOR_TYPE)
+    mag = layer.add_mag(1)
+    mag.write(
+        offset=(10, 20, 30), data=(np.random.rand(50, 60, 70) * 255).astype(np.uint8)
+    )
+
+    assert np.array_equal(mag.read(), mag.read_bbox())
+    assert np.array_equal(
+        mag.read(offset=(20, 30, 40), size=(40, 50, 60)),
+        mag.read_bbox(BoundingBox(topleft=(20, 30, 40), size=(40, 50, 60))),
+    )
+
+
 def test_add_copy_layer(tmp_path: Path) -> None:
     ds = Dataset.create(tmp_path / "ds", scale=(2, 2, 1))
 
@@ -1462,7 +1477,7 @@ def test_add_copy_layer(tmp_path: Path) -> None:
     assert color_layer.mags.keys() == original_color_layer.mags.keys()
     assert len(color_layer.mags.keys()) >= 1
     for mag in color_layer.mags.keys():
-        np.array_equal(
+        assert np.array_equal(
             color_layer.get_mag(mag).read(), original_color_layer.get_mag(mag).read()
         )
         # Test if the copied layer contains actual data

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -950,7 +950,9 @@ def test_writing_subset_of_compressed_data_multi_channel() -> None:
     )
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        warnings.filterwarnings(
+            "ignore", category=RuntimeWarning, module="wkcuber"
+        )  # This line is not necessary. It simply keeps the output of the tests clean.
         write_data2 = (np.random.rand(3, 10, 10, 10) * 255).astype(np.uint8)
         # Writing unaligned data to a compressed dataset works because the data gets padded, but it prints a warning
         # Writing compressed data directly to "compressed_mag" also works, but using a View here covers an additional edge case
@@ -989,7 +991,9 @@ def test_writing_subset_of_compressed_data_single_channel() -> None:
     )
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        warnings.filterwarnings(
+            "ignore", category=RuntimeWarning, module="wkcuber"
+        )  # This line is not necessary. It simply keeps the output of the tests clean.
         write_data2 = (np.random.rand(10, 10, 10) * 255).astype(np.uint8)
         # Writing unaligned data to a compressed dataset works because the data gets padded, but it prints a warning
         # Writing compressed data directly to "compressed_mag" also works, but using a View here covers an additional edge case
@@ -1030,7 +1034,9 @@ def test_writing_subset_of_compressed_data() -> None:
 
     # Calling 'write' with unaligned data on compressed data only fails if the warnings are treated as errors.
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        warnings.filterwarnings(
+            "ignore", category=RuntimeWarning, module="wkcuber"
+        )  # This line is not necessary. It simply keeps the output of the tests clean.
         compressed_mag.write(
             offset=(10, 20, 30),
             data=(np.random.rand(10, 10, 10) * 255).astype(np.uint8),
@@ -1046,8 +1052,6 @@ def test_writing_subset_of_compressed_data() -> None:
 
         # Writing aligned data does not raise a warning. Therefore, this does not fail with these strict settings.
         compressed_mag.write(data=(np.random.rand(64, 64, 64) * 255).astype(np.uint8))
-
-
 
 
 def test_writing_subset_of_chunked_compressed_data() -> None:
@@ -1075,7 +1079,9 @@ def test_writing_subset_of_chunked_compressed_data() -> None:
     )
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        warnings.filterwarnings(
+            "ignore", category=RuntimeWarning, module="wkcuber"
+        )  # This line is not necessary. It simply keeps the output of the tests clean.
 
         # Easy case:
         # The aligned data (offset=(0,0,0), size=(64, 64, 64)) IS fully within the bounding box of the view
@@ -1401,7 +1407,9 @@ def test_compression(tmp_path: Path) -> None:
     )
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        warnings.filterwarnings(
+            "ignore", category=RuntimeWarning, module="wkcuber"
+        )  # This line is not necessary. It simply keeps the output of the tests clean.
         # writing unaligned data to a compressed dataset works because the data gets padded, but it prints a warning
         mag1.write(
             (np.random.rand(3, 10, 20, 30) * 255).astype(np.uint8),

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2,6 +2,7 @@ import filecmp
 import itertools
 import json
 import os
+import warnings
 from os.path import dirname, join
 from pathlib import Path
 from typing import Any, Tuple, cast, Generator
@@ -948,11 +949,14 @@ def test_writing_subset_of_compressed_data_multi_channel() -> None:
         Dataset(TESTOUTPUT_DIR / "compressed_data").get_layer("color").get_mag("1")
     )
 
-    write_data2 = (np.random.rand(3, 10, 10, 10) * 255).astype(np.uint8)
-    # Writing compressed data directly to "compressed_mag" also works, but using a View here covers an additional edge case
-    compressed_mag.get_view(offset=(50, 60, 70)).write(
-        offset=(10, 20, 30), data=write_data2, allow_compressed_write=True
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        write_data2 = (np.random.rand(3, 10, 10, 10) * 255).astype(np.uint8)
+        # Writing unaligned data to a compressed dataset works because the data gets padded, but it prints a warning
+        # Writing compressed data directly to "compressed_mag" also works, but using a View here covers an additional edge case
+        compressed_mag.get_view(offset=(50, 60, 70)).write(
+            offset=(10, 20, 30), data=write_data2
+        )
 
     assert np.array_equal(
         write_data2, compressed_mag.read(offset=(60, 80, 100), size=(10, 10, 10))
@@ -984,11 +988,14 @@ def test_writing_subset_of_compressed_data_single_channel() -> None:
         Dataset(TESTOUTPUT_DIR / "compressed_data").get_layer("color").get_mag("1")
     )
 
-    write_data2 = (np.random.rand(10, 10, 10) * 255).astype(np.uint8)
-    # Writing compressed data directly to "compressed_mag" also works, but using a View here covers an additional edge case
-    compressed_mag.get_view(offset=(50, 60, 70)).write(
-        offset=(10, 20, 30), data=write_data2, allow_compressed_write=True
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        write_data2 = (np.random.rand(10, 10, 10) * 255).astype(np.uint8)
+        # Writing unaligned data to a compressed dataset works because the data gets padded, but it prints a warning
+        # Writing compressed data directly to "compressed_mag" also works, but using a View here covers an additional edge case
+        compressed_mag.get_view(offset=(50, 60, 70)).write(
+            offset=(10, 20, 30), data=write_data2
+        )
 
     assert np.array_equal(
         write_data2, compressed_mag.read(offset=(60, 80, 100), size=(10, 10, 10))[0]
@@ -1021,12 +1028,26 @@ def test_writing_subset_of_compressed_data() -> None:
         Dataset(TESTOUTPUT_DIR / "compressed_data").get_layer("color").get_mag("1")
     )
 
-    with pytest.raises(WKWException):
-        # calling 'write' with unaligned data on compressed data without setting 'allow_compressed_write=True'
+    # Calling 'write' with unaligned data on compressed data only fails if the warnings are treated as errors.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
         compressed_mag.write(
             offset=(10, 20, 30),
             data=(np.random.rand(10, 10, 10) * 255).astype(np.uint8),
         )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error")  # This escalates the warning to an error
+        with pytest.raises(RuntimeWarning):
+            compressed_mag.write(
+                offset=(10, 20, 30),
+                data=(np.random.rand(10, 10, 10) * 255).astype(np.uint8),
+            )
+
+        # Writing aligned data does not raise a warning. Therefore, this does not fail with these strict settings.
+        compressed_mag.write(data=(np.random.rand(64, 64, 64) * 255).astype(np.uint8))
+
+
 
 
 def test_writing_subset_of_chunked_compressed_data() -> None:
@@ -1053,20 +1074,20 @@ def test_writing_subset_of_chunked_compressed_data() -> None:
         .get_view(size=(100, 200, 300))
     )
 
-    # Easy case:
-    # The aligned data (offset=(0,0,0), size=(64, 64, 64)) IS fully within the bounding box of the view
-    write_data2 = (np.random.rand(50, 40, 30) * 255).astype(np.uint8)
-    compressed_view.write(
-        offset=(10, 20, 30), data=write_data2, allow_compressed_write=True
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
 
-    # Advanced case:
-    # The aligned data (offset=(0,0,0), size=(128, 128, 128)) is NOT fully within the bounding box of the view
-    compressed_view.write(
-        offset=(10, 20, 30),
-        data=(np.random.rand(90, 80, 70) * 255).astype(np.uint8),
-        allow_compressed_write=True,
-    )
+        # Easy case:
+        # The aligned data (offset=(0,0,0), size=(64, 64, 64)) IS fully within the bounding box of the view
+        write_data2 = (np.random.rand(50, 40, 30) * 255).astype(np.uint8)
+        compressed_view.write(offset=(10, 20, 30), data=write_data2)
+
+        # Advanced case:
+        # The aligned data (offset=(0,0,0), size=(128, 128, 128)) is NOT fully within the bounding box of the view
+        compressed_view.write(
+            offset=(10, 20, 30),
+            data=(np.random.rand(90, 80, 70) * 255).astype(np.uint8),
+        )
 
     np.array_equal(
         write_data2, compressed_view.read(offset=(10, 20, 30), size=(50, 40, 30))
@@ -1379,14 +1400,12 @@ def test_compression(tmp_path: Path) -> None:
         write_data, mag1.read(offset=(60, 80, 100), size=(10, 20, 30))
     )
 
-    with pytest.raises(wkw.WKWException):
-        # writing unaligned data to a compressed dataset
-        mag1.write((np.random.rand(3, 10, 20, 30) * 255).astype(np.uint8))
-
-    mag1.write(
-        (np.random.rand(3, 10, 20, 30) * 255).astype(np.uint8),
-        allow_compressed_write=True,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module="wkcuber")  # This line is not necessary. It simply keeps the output of the tests clean.
+        # writing unaligned data to a compressed dataset works because the data gets padded, but it prints a warning
+        mag1.write(
+            (np.random.rand(3, 10, 20, 30) * 255).astype(np.uint8),
+        )
 
 
 def test_get_largest_segment_id(tmp_path: Path) -> None:

--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -128,7 +128,6 @@ def downsample_test_helper(use_compress: bool) -> None:
         [2, 2, 2],
         InterpolationModes.MAX,
         CUBE_EDGE_LEN,
-        use_compress,
         100,
     )
 
@@ -185,7 +184,6 @@ def test_downsample_multi_channel() -> None:
         [2, 2, 2],
         InterpolationModes.MAX,
         CUBE_EDGE_LEN,
-        False,
         100,
     )
 

--- a/tests/test_upsampling.py
+++ b/tests/test_upsampling.py
@@ -84,7 +84,6 @@ def upsample_test_helper(use_compress: bool) -> None:
             ),
             [0.5, 0.5, 1.0],
             CUBE_EDGE_LEN,
-            use_compress,
             100,
         )
 
@@ -135,7 +134,6 @@ def test_upsample_multi_channel() -> None:
         (mag2.get_view(), l.get_mag("1").get_view(), 0),
         [0.5, 0.5, 0.5],
         CUBE_EDGE_LEN,
-        False,
         100,
     )
 

--- a/wkcuber/api/layer.py
+++ b/wkcuber/api/layer.py
@@ -419,7 +419,6 @@ class Layer:
                 mag_factors=mag_factors,
                 interpolation_mode=parsed_interpolation_mode,
                 buffer_edge_len=buffer_edge_len,
-                compress=compress,
                 job_count_per_log=job_count_per_log,
             )
 
@@ -549,7 +548,6 @@ class Layer:
                     upsample_cube_job,
                     mag_factors=mag_factors,
                     buffer_edge_len=buffer_edge_len,
-                    compress=compress,
                     job_count_per_log=job_count_per_log,
                 )
                 prev_mag_view.get_view().for_zipped_chunks(

--- a/wkcuber/api/layer.py
+++ b/wkcuber/api/layer.py
@@ -118,7 +118,7 @@ class Layer:
         The parameter `block_len`, `file_len` and `compress` can be
         specified to adjust how the data is stored on disk.
         Note that writing compressed data which is not aligned with the blocks on disk may result in
-        diminished performance, as full blocks will automatically read to pad the write actions. Alternatively,
+        diminished performance, as full blocks will automatically be read to pad the write actions. Alternatively,
         you can call mag.compress() after all the data was written
 
         The return type is `wkcuber.api.mag_view.MagView`.

--- a/wkcuber/api/layer.py
+++ b/wkcuber/api/layer.py
@@ -116,6 +116,9 @@ class Layer:
         Creates a new mag called and adds it to the layer.
         The parameter `block_len`, `file_len` and `compress` can be
         specified to adjust how the data is stored on disk.
+        Note that writing compressed data which is not aligned with the blocks on disk may result in
+        diminished performance, as full blocks will automatically read to pad the write actions. Alternatively,
+        you can call mag.compress() after all the data was written
 
         The return type is `wkcuber.api.mag_view.MagView`.
 

--- a/wkcuber/api/mag_view.py
+++ b/wkcuber/api/mag_view.py
@@ -106,8 +106,8 @@ class MagView(View):
         The `offset` refers to the absolute position, regardless of the offset in the properties (because the global_offset is set to (0, 0, 0)).
         If the data exceeds the original bounding box, the properties are updated.
 
-        If the data on disk is compressed and the passed `data` is not aligned with the files on disk, it is padded by
-        first reading the necessary padding from disk.
+        Note that writing compressed data which is not aligned with the blocks on disk may result in
+        diminished performance, as full blocks will automatically be read to pad the write actions.
         """
         self._assert_valid_num_channels(data.shape)
         super().write(data, offset)

--- a/wkcuber/api/mag_view.py
+++ b/wkcuber/api/mag_view.py
@@ -102,8 +102,7 @@ class MagView(View):
     def write(
         self,
         data: np.ndarray,
-        offset: Tuple[int, int, int] = (0, 0, 0),
-        allow_compressed_write: bool = False,
+        offset: Tuple[int, int, int] = (0, 0, 0)
     ) -> None:
         """
         Writes the `data` at the specified `offset` to disk (like `wkcuber.api.view.View.write()`).
@@ -111,12 +110,11 @@ class MagView(View):
         The `offset` refers to the absolute position, regardless of the offset in the properties (because the global_offset is set to (0, 0, 0)).
         If the data exceeds the original bounding box, the properties are updated.
 
-        If the data on disk is compressed, the passed `data` either has to be aligned with the files on disk
-        or `allow_compressed_write` has to be `True`. If `allow_compressed_write` is `True`, `data` is padded by
+        If the data on disk is compressed and the passed `data` is not aligned with the files on disk, it is padded by
         first reading the necessary padding from disk.
         """
         self._assert_valid_num_channels(data.shape)
-        super().write(data, offset, allow_compressed_write)
+        super().write(data, offset)
         layer_properties = self.layer.dataset.properties.data_layers[self.layer.name]
         current_offset_in_mag1 = layer_properties.get_bounding_box_offset()
         current_size_in_mag1 = layer_properties.get_bounding_box_size()

--- a/wkcuber/api/mag_view.py
+++ b/wkcuber/api/mag_view.py
@@ -99,11 +99,7 @@ class MagView(View):
                 join(layer.dataset.path, layer.name, self.name), self.header
             )
 
-    def write(
-        self,
-        data: np.ndarray,
-        offset: Tuple[int, int, int] = (0, 0, 0)
-    ) -> None:
+    def write(self, data: np.ndarray, offset: Tuple[int, int, int] = (0, 0, 0)) -> None:
         """
         Writes the `data` at the specified `offset` to disk (like `wkcuber.api.view.View.write()`).
 

--- a/wkcuber/api/view.py
+++ b/wkcuber/api/view.py
@@ -82,9 +82,8 @@ class View:
         Writes the `data` at the specified `offset` to disk.
         The `offset` is relative to `global_offset`.
 
-        If the data on disk is compressed and the passed `data` is not aligned with the files on disk, it is padded by
-        first reading the necessary padding from disk.
-        In this particular case, reading data from outside the bounding box is allowed.
+        Note that writing compressed data which is not aligned with the blocks on disk may result in
+        diminished performance, as full blocks will automatically be read to pad the write actions.
         """
         assert not self.read_only, "Cannot write data to an read_only View"
 

--- a/wkcuber/api/view.py
+++ b/wkcuber/api/view.py
@@ -163,6 +163,16 @@ class View:
             cast(Tuple[int, int, int], absolute_offset), size
         )
 
+    def read_bbox(self, bounding_box: Optional[BoundingBox] = None) -> np.array:
+        """
+        The user can specify the `bounding_box` of the requested data.
+        See `read()` for more details.
+        """
+        if bounding_box is None:
+            return self.read()
+        else:
+            return self.read(bounding_box.topleft, bounding_box.size)
+
     def _read_without_checks(
         self,
         absolute_offset: Tuple[int, int, int],

--- a/wkcuber/api/view.py
+++ b/wkcuber/api/view.py
@@ -441,7 +441,10 @@ class View:
             # The absolute offset might be outside of the current view.
             # That is the case if the data is compressed but the view does not include the whole file on disk.
             # In this case we avoid checking the bounds because the aligned_offset and aligned_shape are calculated internally.
-            warnings.warn("Warning: write() was called on a compressed mag without block alignment. Performance will be degraded as the data has to be padded first.", RuntimeWarning)
+            warnings.warn(
+                "Warning: write() was called on a compressed mag without block alignment. Performance will be degraded as the data has to be padded first.",
+                RuntimeWarning,
+            )
             aligned_data = self._read_without_checks(aligned_offset, aligned_shape)
 
             index_slice = (

--- a/wkcuber/downsampling_utils.py
+++ b/wkcuber/downsampling_utils.py
@@ -367,7 +367,7 @@ def downsample_cube_job(
         # Write the downsampled buffer to target
         if source_view.header.num_channels == 1:
             file_buffer = file_buffer[0]  # remove channel dimension
-        target_view.write(file_buffer, allow_compressed_write=compress)
+        target_view.write(file_buffer)
         if use_logging:
             time_stop(f"Downsampling of {target_view.global_offset}")
 

--- a/wkcuber/downsampling_utils.py
+++ b/wkcuber/downsampling_utils.py
@@ -296,7 +296,6 @@ def downsample_cube_job(
     mag_factors: List[int],
     interpolation_mode: InterpolationModes,
     buffer_edge_len: int,
-    compress: bool,
     job_count_per_log: int,
 ) -> None:
     (source_view, target_view, i) = args

--- a/wkcuber/upsampling_utils.py
+++ b/wkcuber/upsampling_utils.py
@@ -99,7 +99,7 @@ def upsample_cube_job(
         # Write the upsampled buffer to target
         if source_view.header.num_channels == 1:
             file_buffer = file_buffer[0]  # remove channel dimension
-        target_view.write(file_buffer, allow_compressed_write=compress)
+        target_view.write(file_buffer)
         if use_logging:
             time_stop(f"Upsampling of {target_view.global_offset}")
 

--- a/wkcuber/upsampling_utils.py
+++ b/wkcuber/upsampling_utils.py
@@ -27,7 +27,6 @@ def upsample_cube_job(
     args: Tuple[View, View, int],
     mag_factors: List[float],
     buffer_edge_len: int,
-    compress: bool,
     job_count_per_log: int,
 ) -> None:
     (source_view, target_view, i) = args


### PR DESCRIPTION
### Description:
- Remove the parameter `allow_compressed_write` from `View.write()`. This parameter existed to avoid that the performance was reduced by making many small write-requests. However, we decided to use warnings for this case.

### Issues:
- fixes #354 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
