### PR TITLE
Add optional make_relative: bool to add_symlink_layer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
+- Added option `make_relative: bool` to `wkcuber.api.dataset.Dataset.add_symlink_layer` to make the symlink relative. [#358](https://github.com/scalableminds/webknossos-cuber/pull/358)
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,18 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
-- Added option `make_relative: bool` to `wkcuber.api.dataset.Dataset.add_symlink_layer` to make the symlink relative. [#358](https://github.com/scalableminds/webknossos-cuber/pull/358)
+
+### Changed
+
+### Fixed
+
+## [0.8.2](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.2) - 2021-07-26
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.1...HEAD)
+
+### Breaking Changes in Config & CLI
+
+### Added
+- Added option `make_relative: bool` to `wkcuber.api.dataset.Dataset.add_symlink_layer` to make the symlink relative. [#360](https://github.com/scalableminds/webknossos-cuber/pull/360)
 
 ### Changed
 

--- a/wkcuber/api/dataset.py
+++ b/wkcuber/api/dataset.py
@@ -408,7 +408,9 @@ class Dataset:
         # delete files on disk
         rmtree(join(self.path, layer_name))
 
-    def add_symlink_layer(self, foreign_layer_path: Union[str, Path], make_relative: bool = False) -> Layer:
+    def add_symlink_layer(
+        self, foreign_layer_path: Union[str, Path], make_relative: bool = False
+    ) -> Layer:
         """
         Creates a symlink to the data at `foreign_layer_path` which belongs to another dataset.
         The relevant information from the `datasource-properties.json` of the other dataset is copied to this dataset.

--- a/wkcuber/api/dataset.py
+++ b/wkcuber/api/dataset.py
@@ -408,14 +408,17 @@ class Dataset:
         # delete files on disk
         rmtree(join(self.path, layer_name))
 
-    def add_symlink_layer(self, foreign_layer_path: Union[str, Path]) -> Layer:
+    def add_symlink_layer(self, foreign_layer_path: Union[str, Path], make_relative: bool = False) -> Layer:
         """
         Creates a symlink to the data at `foreign_layer_path` which belongs to another dataset.
         The relevant information from the `datasource-properties.json` of the other dataset is copied to this dataset.
         Note: If the other dataset modifies its bounding box afterwards, the change does not affect this properties
         (or vice versa).
+        If make_relative is True, the symlink is made relative to the current dataset path.
         """
         foreign_layer_path = Path(os.path.abspath(foreign_layer_path))
+        if make_relative:
+            foreign_layer_path = Path(os.path.relpath(foreign_layer_path, self.path))
         layer_name = foreign_layer_path.name
         if layer_name in self.layers.keys():
             raise IndexError(


### PR DESCRIPTION
### Description:
- If the dataset directory is mounted via docker, absolute symlink paths can break outside of the docker container
- For such cases it is helpful to make the symlink relative instead
- This PR adds the optional parameter `make_relative: bool` to `wkcuber.api.dataset.Dataset.add_symlink_layer`

### Todos:
 - [x] Updated Changelog
