### PR TITLE
default to -1 for largestSegmentId

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Datasets with a missing `largestSegmentId` can now be loaded with a default of `-1`. [#362](https://github.com/scalableminds/webknossos-cuber/pull/362)
 
 ### Fixed
 

--- a/wkcuber/api/properties/layer_properties.py
+++ b/wkcuber/api/properties/layer_properties.py
@@ -266,7 +266,7 @@ class SegmentationLayerProperties(LayerProperties):
             json_data["name"],
             json_data["category"],
             properties_floating_type_to_python_type.get(
-                json_data["elementClass"], json_data["elementClass"],
+                json_data["elementClass"], json_data["elementClass"]
             ),
             json_data["dataFormat"],
             _extract_num_channels(

--- a/wkcuber/api/properties/layer_properties.py
+++ b/wkcuber/api/properties/layer_properties.py
@@ -258,7 +258,7 @@ class SegmentationLayerProperties(LayerProperties):
     ) -> "SegmentationLayerProperties":
         if "largestSegmentId" not in json_data:
             warnings.warn(
-                f"Segmentation layer {json_data["name"]} is missing the 'largestSegmentId', defaulting to -1.",
+                f"Segmentation layer {json_data['name']} is missing the 'largestSegmentId', defaulting to -1.",
                 RuntimeWarning,
             )
         # create LayerProperties without resolutions

--- a/wkcuber/api/properties/layer_properties.py
+++ b/wkcuber/api/properties/layer_properties.py
@@ -1,3 +1,4 @@
+import warnings
 from os.path import join, dirname, isfile
 from pathlib import Path
 from typing import Tuple, Type, Union, Any, Dict, List, Optional, cast
@@ -255,12 +256,17 @@ class SegmentationLayerProperties(LayerProperties):
         resolution_type: Type[Resolution],
         dataset_path: Path,
     ) -> "SegmentationLayerProperties":
+        if "largestSegmentId" not in json_data:
+            warnings.warn(
+                f"Segmentation layer {json_data["name"]} is missing the 'largestSegmentId', defaulting to -1.",
+                RuntimeWarning,
+            )
         # create LayerProperties without resolutions
         layer_properties = cls(
             json_data["name"],
             json_data["category"],
             properties_floating_type_to_python_type.get(
-                json_data["elementClass"], json_data["elementClass"]
+                json_data["elementClass"], json_data["elementClass"],
             ),
             json_data["dataFormat"],
             _extract_num_channels(
@@ -273,7 +279,7 @@ class SegmentationLayerProperties(LayerProperties):
             ),
             json_data["boundingBox"],
             None,
-            json_data["largestSegmentId"],
+            json_data.get("largestSegmentId", -1),
             json_data.get("mappings"),
             json_data.get("defaultViewConfiguration"),
         )


### PR DESCRIPTION
### Description:
Sometimes the `largestSegmentId` is not set in a datasource-properties.json. A default of `-1` is used then, together with a warning about the missing field. When writing the datasource-properties the next time, the field is persisted.

### Todos:
 - [x] Updated Changelog
